### PR TITLE
Add the ability to assign a NAL to Cluster

### DIFF
--- a/cmd/assign.go
+++ b/cmd/assign.go
@@ -1,0 +1,32 @@
+/*
+Copyright © 2022 NAME HERE <EMAIL ADDRESS>
+*/
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// createCmd represents the create command
+var assignCmd = &cobra.Command{
+	Use:   "assign",
+	Short: "Assign a Network Allow List to a Cluster",
+	Long:  "Assign a Network Allow List to a Cluster",
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Help()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(assignCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// createCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// createCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/cdc_stream.go
+++ b/cmd/cdc_stream.go
@@ -37,7 +37,7 @@ var getCdcStreamCmd = &cobra.Command{
 			return
 		}
 
-		resp, r, err := authApi.GetCdcStream(clusterID, cdcStreamID).Execute()
+		resp, r, err := authApi.GetCdcStream(cdcStreamID, clusterID).Execute()
 		if err != nil {
 			logrus.Errorf("Error when calling `CdcApi.GetCdcStream`: %s", ybmAuthClient.GetApiErrorDetails(err))
 			logrus.Debugf("Full HTTP response: %v", r)

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -410,6 +410,11 @@ func (a *AuthApiClient) ListNetworkAllowLists() ybmclient.ApiListNetworkAllowLis
 	return a.ApiClient.NetworkApi.ListNetworkAllowLists(a.ctx, a.AccountID, a.ProjectID)
 }
 
+func (a *AuthApiClient) EditClusterNetworkAllowLists(clusterId string, allowListId string) ybmclient.ApiEditClusterNetworkAllowListsRequest {
+	allowListIDs := []string{allowListId}
+	return a.ApiClient.ClusterApi.EditClusterNetworkAllowLists(a.ctx, a.AccountID, a.ProjectID, clusterId).RequestBody(allowListIDs)
+}
+
 func (a *AuthApiClient) ListBackups() ybmclient.ApiListBackupsRequest {
 	return a.ApiClient.BackupApi.ListBackups(a.ctx, a.AccountID, a.ProjectID)
 }


### PR DESCRIPTION
Today, we can create Network Allow Lists (NAL) and we can create clusters, but we can't assign a NAL to a cluster.

This adds the ability to add a NAL to a cluster.