### PR TITLE
Add the --version / -v flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,8 +34,6 @@ import (
 
 var (
 	cfgFile string
-	// host    string
-	// apiKey  string
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -50,7 +48,8 @@ var rootCmd = &cobra.Command{
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute() {
+func Execute(version string) {
+	rootCmd.Version = version
 	err := rootCmd.Execute()
 	if err != nil {
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -24,5 +24,5 @@ var version = "v0.1.0"
 
 func main() {
 	ybmAuthClient.SetVersion(version)
-	cmd.Execute()
+	cmd.Execute(version)
 }


### PR DESCRIPTION
If customers run into issues, we want to allow them to
report issues to us. For that, we need to be sure of 
what version they are running.

I am adding a --version / -v flag to the execution.
Cobra already supports this functionality as documented
here: https://github.com/spf13/cobra/blob/main/user_guide.md#version-flag