### PR TITLE
Fix -o json with single cluster info

### DIFF
--- a/cmd/cluster/get_cluster.go
+++ b/cmd/cluster/get_cluster.go
@@ -52,7 +52,7 @@ var getClusterCmd = &cobra.Command{
 			logrus.Fatalf("Error when calling `ClusterApi.ListClusters`: %s", ybmAuthClient.GetApiErrorDetails(err))
 		}
 
-		if isGetByName && len(resp.GetData()) > 0 {
+		if isGetByName && len(resp.GetData()) > 0 && viper.GetString("output") == "table" {
 			fullClusterContext := *formatter.NewFullClusterContext()
 			fullClusterContext.Output = os.Stdout
 			fullClusterContext.Format = formatter.NewFullClusterFormat(viper.GetString("output"))

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -71,8 +71,12 @@ func (f *FullCluster) SetVPCs(authApi ybmAuthClient.AuthApiClient) {
 func (f *FullCluster) SetAllowLists(authApi ybmAuthClient.AuthApiClient) {
 	resp, r, err := authApi.ListClusterNetworkAllowLists(f.Cluster.Info.Id).Execute()
 	if err != nil {
-		logrus.Debugf("Full HTTP response: %v", r)
-		logrus.Fatalf("Error when calling `ClusterApi.ListClusterNetworkAllowLists`: %s", ybmAuthClient.GetApiErrorDetails(err))
+		if err.Error() == "409 Conflict" {
+			logrus.Debug("Failed to get allow lists because cluster %s is not ready yet", f.Cluster.Info.Id)
+		} else {
+			logrus.Debugf("Full HTTP response: %v", r)
+			logrus.Fatalf("Error when calling `ClusterApi.ListClusterNetworkAllowLists`: %s", ybmAuthClient.GetApiErrorDetails(err))
+		}
 	}
 	if _, ok := resp.GetDataOk(); ok {
 		f.AllowList = resp.GetData()

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -72,7 +72,7 @@ func (f *FullCluster) SetAllowLists(authApi ybmAuthClient.AuthApiClient) {
 	resp, r, err := authApi.ListClusterNetworkAllowLists(f.Cluster.Info.Id).Execute()
 	if err != nil {
 		if err.Error() == "409 Conflict" {
-			logrus.Debug("Failed to get allow lists because cluster %s is not ready yet", f.Cluster.Info.Id)
+			logrus.Debugf("Failed to get allow lists because cluster %s is not ready yet", f.Cluster.Info.Id)
 		} else {
 			logrus.Debugf("Full HTTP response: %v", r)
 			logrus.Fatalf("Error when calling `ClusterApi.ListClusterNetworkAllowLists`: %s", ybmAuthClient.GetApiErrorDetails(err))


### PR DESCRIPTION
In case there is a `--cluster-name cluster`
specified for `cluster get`, it defaults to a
table view regardless of what the user specified.

Making it such that the display is detailed only if the user wants a table.

Also fixing a bug where detailed display fails if the cluster is not ready because the call to fetch the allow lists fails.