### PR TITLE
output only the error detail instead of the full log error message

### DIFF
--- a/cmd/backup/backup.go
+++ b/cmd/backup/backup.go
@@ -58,7 +58,7 @@ var getBackupCmd = &cobra.Command{
 		resp, r, err := listBackupRequest.Execute()
 		if err != nil {
 			logrus.Debugf("Full HTTP response: %v", r)
-			logrus.Fatalf("Error when calling `BackupApi.ListBackups`: %s", ybmAuthClient.GetApiErrorDetails(err))
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 		backupsCtx := formatter.Context{
 			Output: os.Stdout,
@@ -94,7 +94,7 @@ var restoreBackupCmd = &cobra.Command{
 		_, r, err := authApi.RestoreBackup().RestoreSpec(*restoreSpec).Execute()
 		if err != nil {
 			logrus.Debugf("Full HTTP response: %v", r)
-			logrus.Fatalf("Error when calling `BackupApi.RestoreBackup`: %s", ybmAuthClient.GetApiErrorDetails(err))
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 		msg := fmt.Sprintf("Backup %v is being restored onto the cluster %v", formatter.Colorize(backupID, formatter.GREEN_COLOR), formatter.Colorize(clusterName, formatter.GREEN_COLOR))
 
@@ -149,7 +149,7 @@ var createBackupCmd = &cobra.Command{
 		backupResp, response, err := authApi.CreateBackup().BackupSpec(createBackupSpec).Execute()
 		if err != nil {
 			logrus.Debugf("Full HTTP response: %v", response)
-			logrus.Fatalf("Error when calling `BackupApi.CreateBackup`: %s", ybmAuthClient.GetApiErrorDetails(err))
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 		backupID := backupResp.GetData().Info.Id
 
@@ -168,7 +168,7 @@ var createBackupCmd = &cobra.Command{
 			respC, r, err := authApi.GetBackup(*backupID).Execute()
 			if err != nil {
 				logrus.Debugf("Full HTTP response: %v", r)
-				logrus.Fatalf("Error when calling `BackupApi.ListBackups`: %s", ybmAuthClient.GetApiErrorDetails(err))
+				logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 			}
 			backupResp = respC
 		} else {
@@ -200,7 +200,7 @@ var deleteBackupCmd = &cobra.Command{
 
 		if err != nil {
 			logrus.Debugf("Full HTTP response: %v", response)
-			logrus.Fatalf("Error when calling `BackupApi.DeleteBackup`: %s", ybmAuthClient.GetApiErrorDetails(err))
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 
 		fmt.Printf("The backup %s is being queued for deletion.\n", formatter.Colorize(backupID, formatter.GREEN_COLOR))

--- a/cmd/cluster/assign_nal_cluster.go
+++ b/cmd/cluster/assign_nal_cluster.go
@@ -50,7 +50,7 @@ var assignClusterCmd = &cobra.Command{
 		networkAllowListListResp, r, err := authApi.ListClusterNetworkAllowLists(clusterId).Execute()
 		if err != nil {
 			logrus.Debugf("Full HTTP response: %v", r)
-			logrus.Fatalf("Error when calling `ClusterApi.ListClusterNetworkAllowLists`: %s", ybmAuthClient.GetApiErrorDetails(err))
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 
 		allowListIds := []string{}
@@ -62,7 +62,7 @@ var assignClusterCmd = &cobra.Command{
 		_, r, err = authApi.EditClusterNetworkAllowLists(clusterId, allowListIds).Execute()
 		if err != nil {
 			logrus.Debugf("Full HTTP response: %v", r)
-			logrus.Fatalf("Error when calling `ClusterApi.EditClusterNetworkAllowLists`: %s", ybmAuthClient.GetApiErrorDetails(err))
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 
 		msg := fmt.Sprintf("The network allow list %s is being assigned to the cluster %s", formatter.Colorize(newNetworkAllowListName, formatter.GREEN_COLOR), formatter.Colorize(clusterName, formatter.GREEN_COLOR))

--- a/cmd/cluster/cloud_regions.go
+++ b/cmd/cluster/cloud_regions.go
@@ -40,7 +40,7 @@ var getCloudRegionsCmd = &cobra.Command{
 		cloudRegionsResp, resp, err := authApi.GetSupportedCloudRegions().Cloud(cloudProvider).Execute()
 		if err != nil {
 			logrus.Debugf("Full HTTP response: %v", resp)
-			logrus.Fatalf("Error when calling `ClusterApi.GetSupportedCloudRegions`: %s", ybmAuthClient.GetApiErrorDetails(err))
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 
 		cloudRegionData := cloudRegionsResp.GetData()

--- a/cmd/cluster/create_cluster.go
+++ b/cmd/cluster/create_cluster.go
@@ -93,7 +93,7 @@ var createClusterCmd = &cobra.Command{
 
 		clusterSpec, err := authApi.CreateClusterSpec(cmd, regionInfoMapList)
 		if err != nil {
-			logrus.Fatalf("Error while creating cluster spec: %v", ybmAuthClient.GetApiErrorDetails(err))
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 
 		dbCredentials := ybmclient.NewCreateClusterRequestDbCredentials()
@@ -105,7 +105,7 @@ var createClusterCmd = &cobra.Command{
 		resp, r, err := authApi.CreateCluster().CreateClusterRequest(*createClusterRequest).Execute()
 		if err != nil {
 			logrus.Debugf("Full HTTP response: %v", r)
-			logrus.Fatalf("Error when calling `ClusterApi.CreateCluster`: %s", ybmAuthClient.GetApiErrorDetails(err))
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 
 		clusterID := resp.GetData().Info.Id
@@ -126,7 +126,7 @@ var createClusterCmd = &cobra.Command{
 			respC, r, err := authApi.ListClusters().Name(clusterName).Execute()
 			if err != nil {
 				logrus.Debugf("Full HTTP response: %v", r)
-				logrus.Fatalf("Error when calling `ClusterApi.ListClusters`: %s", ybmAuthClient.GetApiErrorDetails(err))
+				logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 			}
 			clusterData = respC.GetData()
 		} else {

--- a/cmd/cluster/delete_cluster.go
+++ b/cmd/cluster/delete_cluster.go
@@ -45,7 +45,7 @@ var deleteClusterCmd = &cobra.Command{
 		r, err := authApi.DeleteCluster(clusterID).Execute()
 		if err != nil {
 			logrus.Debugf("Full HTTP response: %v", r)
-			logrus.Fatalf("Error when calling `ClusterApi.DeleteCluster`: %s", ybmAuthClient.GetApiErrorDetails(err))
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 
 		msg := fmt.Sprintf("The cluster %s is being deleted", formatter.Colorize(clusterName, formatter.GREEN_COLOR))

--- a/cmd/cluster/get_cluster.go
+++ b/cmd/cluster/get_cluster.go
@@ -49,7 +49,7 @@ var getClusterCmd = &cobra.Command{
 
 		if err != nil {
 			logrus.Debugf("Full HTTP response: %v", r)
-			logrus.Fatalf("Error when calling `ClusterApi.ListClusters`: %s", ybmAuthClient.GetApiErrorDetails(err))
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 
 		if isGetByName && len(resp.GetData()) > 0 {

--- a/cmd/cluster/instance_types.go
+++ b/cmd/cluster/instance_types.go
@@ -48,7 +48,7 @@ var getInstanceTypesCmd = &cobra.Command{
 		instanceTypesResp, resp, err := authApi.GetSupportedInstanceTypes(cloudProvider, tier, cloudRegion).ShowDisabled(showDisabled).Execute()
 		if err != nil {
 			logrus.Debugf("Full HTTP response: %v", resp)
-			logrus.Fatalf("Error when calling `ClusterApi.GetSupportedInstanceTypes`: %s", ybmAuthClient.GetApiErrorDetails(err))
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 
 		instanceTypeData := instanceTypesResp.GetData()[cloudRegion]

--- a/cmd/cluster/pause_cluster.go
+++ b/cmd/cluster/pause_cluster.go
@@ -47,7 +47,7 @@ var pauseClusterCmd = &cobra.Command{
 		resp, r, err := authApi.PauseCluster(clusterID).Execute()
 		if err != nil {
 			logrus.Debugf("Full HTTP response: %v", r)
-			logrus.Fatalf("Error when calling `ClusterApi.PauseCluster`: %s", ybmAuthClient.GetApiErrorDetails(err))
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 		clusterData := []ybmclient.ClusterData{resp.GetData()}
 
@@ -66,7 +66,7 @@ var pauseClusterCmd = &cobra.Command{
 			respC, r, err := authApi.ListClusters().Name(clusterName).Execute()
 			if err != nil {
 				logrus.Debugf("Full HTTP response: %v", r)
-				logrus.Fatalf("Error when calling `ClusterApi.ListClusters`: %s", ybmAuthClient.GetApiErrorDetails(err))
+				logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 			}
 			clusterData = respC.GetData()
 		} else {

--- a/cmd/cluster/resume_cluster.go
+++ b/cmd/cluster/resume_cluster.go
@@ -46,7 +46,7 @@ var resumeClusterCmd = &cobra.Command{
 		resp, r, err := authApi.ResumeCluster(clusterID).Execute()
 		if err != nil {
 			logrus.Debugf("Full HTTP response: %v", r)
-			logrus.Fatalf("Error when calling `ClusterApi.ResumeCluster`: %s", ybmAuthClient.GetApiErrorDetails(err))
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 
 		clusterData := []ybmclient.ClusterData{resp.GetData()}
@@ -66,7 +66,7 @@ var resumeClusterCmd = &cobra.Command{
 			respC, r, err := authApi.ListClusters().Name(clusterName).Execute()
 			if err != nil {
 				logrus.Debugf("Full HTTP response: %v", r)
-				logrus.Fatalf("Error when calling `ClusterApi.ListClusters`: %s", ybmAuthClient.GetApiErrorDetails(err))
+				logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 			}
 			clusterData = respC.GetData()
 		} else {

--- a/cmd/cluster/unassign_nal_cluster.go
+++ b/cmd/cluster/unassign_nal_cluster.go
@@ -50,7 +50,7 @@ var unassignClusterCmd = &cobra.Command{
 		networkAllowListListResp, r, err := authApi.ListClusterNetworkAllowLists(clusterId).Execute()
 		if err != nil {
 			logrus.Debugf("Full HTTP response: %v", r)
-			logrus.Fatalf("Error when calling `ClusterApi.ListClusterNetworkAllowLists`: %s", ybmAuthClient.GetApiErrorDetails(err))
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 
 		allowListIds := []string{}
@@ -70,7 +70,7 @@ var unassignClusterCmd = &cobra.Command{
 		_, r, err = authApi.EditClusterNetworkAllowLists(clusterId, allowListIds).Execute()
 		if err != nil {
 			logrus.Debugf("Full HTTP response: %v", r)
-			logrus.Fatalf("Error when calling `ClusterApi.EditClusterNetworkAllowLists`: %s", ybmAuthClient.GetApiErrorDetails(err))
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 
 		msg := fmt.Sprintf("The network allow list %s is being unassigned from the cluster %s", formatter.Colorize(newNetworkAllowListName, formatter.GREEN_COLOR), formatter.Colorize(clusterName, formatter.GREEN_COLOR))

--- a/cmd/cluster/update_cluster.go
+++ b/cmd/cluster/update_cluster.go
@@ -49,14 +49,14 @@ var updateClusterCmd = &cobra.Command{
 		resp, r, err := authApi.GetCluster(clusterID).Execute()
 		if err != nil {
 			logrus.Debugf("Full HTTP response: %v", r)
-			logrus.Fatalf("Error when calling `ClusterApi.GetCluster`: %s", ybmAuthClient.GetApiErrorDetails(err))
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 
 		originalSpec := resp.Data.GetSpec()
 		trackID := originalSpec.SoftwareInfo.GetTrackId()
 		trackName, err := authApi.GetTrackNameById(trackID)
 		if err != nil {
-			logrus.Fatalf("Error when calling `getTrackName`: %s", ybmAuthClient.GetApiErrorDetails(err))
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 
 		populateFlags(cmd, originalSpec, trackName, authApi)
@@ -119,7 +119,7 @@ var updateClusterCmd = &cobra.Command{
 		resp, r, err = authApi.EditCluster(clusterID).ClusterSpec(*clusterSpec).Execute()
 		if err != nil {
 			logrus.Debugf("Full HTTP response: %v", r)
-			logrus.Fatalf("Error when calling `ClusterApi.UpdateCluster`: %s", ybmAuthClient.GetApiErrorDetails(err))
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 		clusterData := []ybmclient.ClusterData{resp.GetData()}
 
@@ -138,7 +138,7 @@ var updateClusterCmd = &cobra.Command{
 			respC, r, err := authApi.ListClusters().Name(clusterName).Execute()
 			if err != nil {
 				logrus.Debugf("Full HTTP response: %v", r)
-				logrus.Fatalf("Error when calling `ClusterApi.ListClusters`: %s", ybmAuthClient.GetApiErrorDetails(err))
+				logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 			}
 			clusterData = respC.GetData()
 		} else {
@@ -232,7 +232,7 @@ func populateFlags(cmd *cobra.Command, originalSpec ybmclient.ClusterSpec, track
 			if vpcID, ok := clusterRegionInfo.PlacementInfo.GetVpcIdOk(); ok && vpcID != nil {
 				vpcName, err := authApi.GetVpcNameById(*vpcID)
 				if err != nil {
-					logrus.Fatalf("Error when calling `getVpcName`: %s", ybmAuthClient.GetApiErrorDetails(err))
+					logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 					return
 				}
 				regionInfo += ",vpc=" + vpcName

--- a/cmd/vpc/vpc.go
+++ b/cmd/vpc/vpc.go
@@ -55,7 +55,7 @@ var getVpcCmd = &cobra.Command{
 		resp, r, err := vpcListRequest.Execute()
 		if err != nil {
 			logrus.Debugf("Full HTTP response: %v", r)
-			logrus.Fatalf("Error when calling `NetworkApi.ListSingleTenantVpcs`: %s", ybmAuthClient.GetApiErrorDetails(err))
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 		// response from `ListClusters`: ClusterListResponse
 		vpcCtx := formatter.Context{
@@ -130,7 +130,7 @@ var createVpcCmd = &cobra.Command{
 		resp, r, err := authApi.CreateVpc().SingleTenantVpcRequest(vpcRequest).Execute()
 		if err != nil {
 			logrus.Debugf("Full HTTP response: %v", r)
-			logrus.Fatalf("Error when calling `NetworkApi.CreateVpc`: %s", ybmAuthClient.GetApiErrorDetails(err))
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 		vpcID := resp.Data.GetInfo().Id
 		vpcData := []ybmclient.SingleTenantVpcDataResponse{resp.GetData()}
@@ -151,7 +151,7 @@ var createVpcCmd = &cobra.Command{
 			respC, r, err := vpcListRequest.Execute()
 			if err != nil {
 				logrus.Debugf("Full HTTP response: %v", r)
-				logrus.Fatalf("Error when calling `NetworkApi.ListSingleTenantVpcs`: %s", ybmAuthClient.GetApiErrorDetails(err))
+				logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 			}
 			vpcData = respC.GetData()
 		} else {
@@ -187,7 +187,7 @@ var deleteVpcCmd = &cobra.Command{
 		r, err := authApi.DeleteVpc(vpcId).Execute()
 		if err != nil {
 			logrus.Debugf("Full HTTP response: %v", r)
-			logrus.Fatalf("Error when calling `NetworkApi.DeleteVpc`: %s", ybmAuthClient.GetApiErrorDetails(err))
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 
 		msg := fmt.Sprintf("The VPC %s is being deleted", formatter.Colorize(vpcName, formatter.GREEN_COLOR))

--- a/cmd/vpcpeering/vpc_peering.go
+++ b/cmd/vpcpeering/vpc_peering.go
@@ -61,7 +61,7 @@ var getVpcPeeringCmd = &cobra.Command{
 		resp, r, err := authApi.ListVpcPeerings().Execute()
 		if err != nil {
 			logrus.Errorf("Full HTTP response: %v", r)
-			logrus.Fatalf("Error when calling `NetworkApi.ListVpcPeerings`: %s", ybmAuthClient.GetApiErrorDetails(err))
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 
 		vpcPeeringCtx := formatter.Context{
@@ -164,7 +164,7 @@ var createVpcPeeringCmd = &cobra.Command{
 		ybVpcResp, resp, err := authApi.GetSingleTenantVpc(ybVpcId).Execute()
 		if err != nil {
 			logrus.Debugf("Full HTTP response: %v", resp)
-			logrus.Fatalf("Error when calling `GetSingleTenantVpc`: %s", ybmAuthClient.GetApiErrorDetails(err))
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 		ybVpcCloud := string(ybVpcResp.Data.Spec.GetCloud())
 
@@ -177,7 +177,7 @@ var createVpcPeeringCmd = &cobra.Command{
 		vpcPeeringResp, response, err := authApi.CreateVpcPeering().VpcPeeringSpec(vpcPeeringSpec).Execute()
 		if err != nil {
 			logrus.Errorf("Full HTTP response: %v", response)
-			logrus.Fatalf("Error when calling `NetworkApi.CreateVpcPeering`: %s", ybmAuthClient.GetApiErrorDetails(err))
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 
 		vpcPeeringID := vpcPeeringResp.GetData().Info.Id
@@ -197,7 +197,7 @@ var createVpcPeeringCmd = &cobra.Command{
 			vpcPeeringResp, response, err = authApi.GetVpcPeering(vpcPeeringID).Execute()
 			if err != nil {
 				logrus.Errorf("Full HTTP response: %v", response)
-				logrus.Fatalf("Error when calling `NetworkApi.ListVpcPeerings`: %s", ybmAuthClient.GetApiErrorDetails(err))
+				logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 			}
 
 		} else {
@@ -229,7 +229,7 @@ var deleteVpcPeeringCmd = &cobra.Command{
 		resp, r, err := authApi.ListVpcPeerings().Execute()
 		if err != nil {
 			logrus.Errorf("Full HTTP response: %v", r)
-			logrus.Fatalf("Error when calling `NetworkApi.ListVpcPeerings`: %s", ybmAuthClient.GetApiErrorDetails(err))
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 
 		// check vpcPeeringName exists
@@ -243,7 +243,7 @@ var deleteVpcPeeringCmd = &cobra.Command{
 		response, err := authApi.DeleteVpcPeering(vpcPeeringId).Execute()
 		if err != nil {
 			logrus.Debugf("Full HTTP response: %v", response)
-			logrus.Fatalf("Error when calling `NetworkApi.ListVpcPeerings`: %s", ybmAuthClient.GetApiErrorDetails(err))
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 		msg := fmt.Sprintf("VPC peering %s is being terminated", formatter.Colorize(vpcPeeringName, formatter.GREEN_COLOR))
 

--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
+	github.com/t-tomalak/logrus-easy-formatter v0.0.0-20190827215021-c074f06c5816 // indirect
 	golang.org/x/crypto v0.6.0 // indirect
 	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/oauth2 v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -166,6 +166,7 @@ github.com/jayco/go-emoji-flag v0.0.0-20190810054606-01604da018da/go.mod h1:HJ4F
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
@@ -214,6 +215,7 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
+github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/spf13/afero v1.9.4 h1:Sd43wM1IWz/s1aVXdOBkjJvuP8UdyqioeE4AmM0QsBs=
@@ -230,6 +232,7 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.15.0 h1:js3yy885G8xwJa6iOISGFwd+qlUo5AvyXb7CiihdtiU=
 github.com/spf13/viper v1.15.0/go.mod h1:fFcTBJxvhhzSJiZy8n+PeW6t8l+KeT/uTARa0jHOQLA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
@@ -242,6 +245,8 @@ github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKs
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/subosito/gotenv v1.4.2 h1:X1TuBLAMDFbaTAChgCBLu3DU3UPyELpnF2jjJ2cz/S8=
 github.com/subosito/gotenv v1.4.2/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
+github.com/t-tomalak/logrus-easy-formatter v0.0.0-20190827215021-c074f06c5816 h1:J6v8awz+me+xeb/cUTotKgceAYouhIB3pjzgRd6IlGk=
+github.com/t-tomalak/logrus-easy-formatter v0.0.0-20190827215021-c074f06c5816/go.mod h1:tzym/CEb5jnFI+Q0k4Qq3+LvRF4gO3E2pxS8fHP8jcA=
 github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20230128004341-7bd09f253ed8 h1:mq9vH0tGfDNa0BQWiuQM0TJsA6wdxB8kHdkAROD8cYk=
 github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20230128004341-7bd09f253ed8/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -794,7 +794,7 @@ func GetApiErrorDetails(err error) string {
 	case ybmclient.GenericOpenAPIError:
 		if v := getAPIError(castedError.Body()); v != nil {
 			if d, ok := v.GetErrorOk(); ok {
-				return fmt.Sprintf("%s-%s", err.Error(), d.GetDetail())
+				return fmt.Sprintf("%s%s", d.GetDetail(), "\n")
 			}
 		}
 	}

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -58,7 +58,7 @@ func (f *FullCluster) SetVPCs(authApi ybmAuthClient.AuthApiClient) {
 		resp, r, err := authApi.ListSingleTenantVpcs().Ids(VpcIds).Execute()
 		if err != nil {
 			logrus.Debugf("Full HTTP response: %v", r)
-			logrus.Fatalf("Error when calling `NetworkApi.ListSingleTenantVpcs`: %s", ybmAuthClient.GetApiErrorDetails(err))
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 		if _, ok := resp.GetDataOk(); ok {
 			for _, v := range resp.GetData() {
@@ -72,7 +72,7 @@ func (f *FullCluster) SetAllowLists(authApi ybmAuthClient.AuthApiClient) {
 	resp, r, err := authApi.ListClusterNetworkAllowLists(f.Cluster.Info.Id).Execute()
 	if err != nil {
 		logrus.Debugf("Full HTTP response: %v", r)
-		logrus.Fatalf("Error when calling `ClusterApi.ListClusterNetworkAllowLists`: %s", ybmAuthClient.GetApiErrorDetails(err))
+		logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 	}
 	if _, ok := resp.GetDataOk(); ok {
 		f.AllowList = resp.GetData()

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -18,22 +18,14 @@ package log
 import (
 	"fmt"
 	"os"
-	"path/filepath"
-	"runtime"
 
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
+	easy "github.com/t-tomalak/logrus-easy-formatter"
 )
 
 func SetFormatter() {
-	logrus.SetReportCaller(true)
-	logrus.SetFormatter(&logrus.TextFormatter{
-		DisableColors:          viper.GetBool("no-color"),
-		DisableLevelTruncation: true,
-		CallerPrettyfier: func(f *runtime.Frame) (string, string) {
-			//We don't need the full path to just returning the file
-			return "", fmt.Sprintf("%s:%d", filepath.Base(f.File), f.Line)
-		},
+	logrus.SetFormatter(&easy.Formatter{
+		LogFormat: "%msg%",
 	})
 }
 

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -18,8 +18,11 @@ package log
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+	"runtime"
 
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
 	easy "github.com/t-tomalak/logrus-easy-formatter"
 )
 
@@ -29,10 +32,23 @@ func SetFormatter() {
 	})
 }
 
+func SetDebugFormatter() {
+	logrus.SetReportCaller(true)
+	logrus.SetFormatter(&logrus.TextFormatter{
+		DisableColors:          viper.GetBool("no-color"),
+		DisableLevelTruncation: true,
+		CallerPrettyfier: func(f *runtime.Frame) (string, string) {
+			//We don't need the full path to just returning the file
+			return "", fmt.Sprintf("%s:%d", filepath.Base(f.File), f.Line)
+		},
+	})
+}
+
 func SetLogLevel(logLevel string, debug bool) {
 
 	if debug {
 		logrus.SetLevel(logrus.DebugLevel)
+		SetDebugFormatter()
 		return
 	}
 	if logLevel != "" {


### PR DESCRIPTION
The output now looks like the following:
```
bash-5.2$ make build
go build -ldflags="-X 'main.version=v0.1.0'" -o ybm
bash-5.2$ ./ybm cluster pause --cluster-name twinkling-caterpillar
Cannot pause a free tier cluster
bash-5.2$ 
```