### PR TITLE
Display endpoints in describe cluster view

### DIFF
--- a/cmd/cluster_test.go
+++ b/cmd/cluster_test.go
@@ -237,14 +237,19 @@ Provider   Tier        Fault Tolerance   Nodes     Total Res.\(Vcpu/Mem/Disk\)
 AWS        Dedicated   NONE              1         2 / 8GB / 100GB
 
 
-Network AllowList
-Name              Description       Allow List
-device-ip-gween   device-ip-gween   152.165.26.42/32
-
-
 Regions
 Region      Nodes     vCPU/Node   Mem/Node   Disk/Node   VPC
-us-west-2   1         2           8GB        100GB`))
+us-west-2   1         2           8GB        100GB       
+
+
+Endpoints
+Region      Accessibility   State     Host
+us-west-2   PUBLIC          ACTIVE    us-west-2.a49ee751-6c5d-490f-8d38-347cefc9d53c.fake.yugabyte.com
+
+
+Network AllowList
+Name              Description       Allow List
+device-ip-gween   device-ip-gween   152.165.26.42/32`))
 				session.Kill()
 			})
 			It("should return only header when cluster-name is wrong", func() {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -67,6 +67,12 @@ func NewAuthApiClient() (*AuthApiClient, error) {
 	configuration.Scheme = url.Scheme
 	apiClient := ybmclient.NewAPIClient(configuration)
 	apiKey := viper.GetString("apiKey")
+
+	// If the api key is empty, then tell the user to run the auth command.
+	if len(apiKey) == 0 {
+		logrus.Fatalln("No valid API key detected. Please run `ybm auth` to authenticate with YugabyteDB Managed.")
+	}
+
 	apiClient.GetConfig().AddDefaultHeader("Authorization", "Bearer "+apiKey)
 	apiClient.GetConfig().UserAgent = "ybm-cli/" + cliVersion
 	ctx, _ := signal.NotifyContext(context.Background(), os.Interrupt)


### PR DESCRIPTION
This PR fixes two things:

* display the endpoints in the `cluster describe` view
* when the user did not run `ybm auth` and tries to run a commend, they get an ugly 401. Prompt the user to run `ybm auth`.