### PR TITLE
fix enum type

### DIFF
--- a/cmd/backup/backup.go
+++ b/cmd/backup/backup.go
@@ -111,7 +111,7 @@ var restoreBackupCmd = &cobra.Command{
 		msg := fmt.Sprintf("Backup %v is being restored onto the cluster %v", formatter.Colorize(backupID, formatter.GREEN_COLOR), formatter.Colorize(clusterName, formatter.GREEN_COLOR))
 
 		if viper.GetBool("wait") {
-			returnStatus, err := authApi.WaitForTaskCompletion(clusterID, "CLUSTER", "RESTORE_BACKUP", []string{"FAILED", "SUCCEEDED"}, msg, 600)
+			returnStatus, err := authApi.WaitForTaskCompletion(clusterID, ybmclient.ENTITYTYPEENUM_CLUSTER, ybmclient.TASKTYPEENUM_RESTORE_BACKUP, []string{"FAILED", "SUCCEEDED"}, msg, 600)
 			if err != nil {
 				logrus.Fatalf("error when getting task status: %s", err)
 			}
@@ -168,7 +168,7 @@ var createBackupCmd = &cobra.Command{
 		msg := fmt.Sprintf("The backup for cluster %s is being created", formatter.Colorize(clusterName, formatter.GREEN_COLOR))
 
 		if viper.GetBool("wait") {
-			returnStatus, err := authApi.WaitForTaskCompletion(*backupID, "BACKUP", "CREATE_BACKUP", []string{"FAILED", "SUCCEEDED"}, msg, 600)
+			returnStatus, err := authApi.WaitForTaskCompletion(*backupID, ybmclient.ENTITYTYPEENUM_BACKUP, ybmclient.TASKTYPEENUM_CREATE_BACKUP, []string{"FAILED", "SUCCEEDED"}, msg, 600)
 			if err != nil {
 				logrus.Fatalf("error when getting task status: %s", err)
 			}

--- a/cmd/cdc/cdc_stream.go
+++ b/cmd/cdc/cdc_stream.go
@@ -126,7 +126,7 @@ var createCdcStreamCmd = &cobra.Command{
 		msg := fmt.Sprintf("The CDC stream %s is being created", formatter.Colorize(cdcStreamName, formatter.GREEN_COLOR))
 
 		if viper.GetBool("wait") {
-			returnStatus, err := authApi.WaitForTaskCompletion(clusterID, "CLUSTER", "CREATE_CDC_SERVICE", []string{"FAILED", "SUCCEEDED"}, msg, 1200)
+			returnStatus, err := authApi.WaitForTaskCompletion(clusterID, ybmclient.ENTITYTYPEENUM_CLUSTER, ybmclient.TASKTYPEENUM_CREATE_CDC_SERVICE, []string{"FAILED", "SUCCEEDED"}, msg, 1200)
 			if err != nil {
 				logrus.Fatalf("error when getting task status: %s", err)
 			}
@@ -186,7 +186,7 @@ var editCdcStreamCmd = &cobra.Command{
 		if viper.GetBool("wait") {
 
 			if cmd.Flags().Changed("tables") {
-				returnStatus, err := authApi.WaitForTaskCompletion(clusterID, "CLUSTER", "RECONFIGURE_CDC_SERVICE", []string{"FAILED", "SUCCEEDED"}, msg, 1200)
+				returnStatus, err := authApi.WaitForTaskCompletion(clusterID, ybmclient.ENTITYTYPEENUM_CLUSTER, ybmclient.TASKTYPEENUM_RECONFIGURE_CDC_SERVICE, []string{"FAILED", "SUCCEEDED"}, msg, 1200)
 				if err != nil {
 					logrus.Fatalf("error when getting task status: %s", err)
 				}
@@ -238,7 +238,7 @@ var deleteCdcStreamCmd = &cobra.Command{
 		msg := fmt.Sprintf("The CDC stream %s is being deleted", formatter.Colorize(cdcStreamName, formatter.GREEN_COLOR))
 
 		if viper.GetBool("wait") {
-			returnStatus, err := authApi.WaitForTaskCompletion(clusterID, "CLUSTER", "DELETE_CDC_SERVICE", []string{"FAILED", "SUCCEEDED"}, msg, 1200)
+			returnStatus, err := authApi.WaitForTaskCompletion(clusterID, ybmclient.ENTITYTYPEENUM_CLUSTER, ybmclient.TASKTYPEENUM_DELETE_CDC_SERVICE, []string{"FAILED", "SUCCEEDED"}, msg, 1200)
 			if err != nil {
 				logrus.Fatalf("error when getting task status: %s", err)
 			}

--- a/cmd/cluster/create_cluster.go
+++ b/cmd/cluster/create_cluster.go
@@ -96,9 +96,9 @@ var createClusterCmd = &cobra.Command{
 			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 
-		dbCredentials := ybmclient.NewCreateClusterRequestDbCredentials()
-		dbCredentials.Ycql = ybmclient.NewDBCredentials(username, password)
-		dbCredentials.Ysql = ybmclient.NewDBCredentials(username, password)
+		dbCredentials := ybmclient.NewCreateClusterRequestDbCredentialsWithDefaults()
+		dbCredentials.Ycql = *ybmclient.NewDBCredentials(username, password)
+		dbCredentials.Ysql = *ybmclient.NewDBCredentials(username, password)
 
 		createClusterRequest := ybmclient.NewCreateClusterRequest(*clusterSpec, *dbCredentials)
 
@@ -114,7 +114,7 @@ var createClusterCmd = &cobra.Command{
 		msg := fmt.Sprintf("The cluster %s is being created", formatter.Colorize(clusterName, formatter.GREEN_COLOR))
 
 		if viper.GetBool("wait") {
-			returnStatus, err := authApi.WaitForTaskCompletion(clusterID, "CLUSTER", "CREATE_CLUSTER", []string{"FAILED", "SUCCEEDED"}, msg, 1800)
+			returnStatus, err := authApi.WaitForTaskCompletion(clusterID, ybmclient.ENTITYTYPEENUM_CLUSTER, ybmclient.TASKTYPEENUM_CREATE_CLUSTER, []string{"FAILED", "SUCCEEDED"}, msg, 1800)
 			if err != nil {
 				logrus.Fatalf("error when getting task status: %s", err)
 			}

--- a/cmd/cluster/delete_cluster.go
+++ b/cmd/cluster/delete_cluster.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/viper"
 	ybmAuthClient "github.com/yugabyte/ybm-cli/internal/client"
 	"github.com/yugabyte/ybm-cli/internal/formatter"
+	ybmclient "github.com/yugabyte/yugabytedb-managed-go-client-internal"
 )
 
 // deleteClusterCmd represents the cluster command
@@ -51,7 +52,7 @@ var deleteClusterCmd = &cobra.Command{
 		msg := fmt.Sprintf("The cluster %s is being deleted", formatter.Colorize(clusterName, formatter.GREEN_COLOR))
 
 		if viper.GetBool("wait") {
-			returnStatus, err := authApi.WaitForTaskCompletion(clusterID, "CLUSTER", "DELETE_CLUSTER", []string{"FAILED", "SUCCEEDED"}, msg, 1800)
+			returnStatus, err := authApi.WaitForTaskCompletion(clusterID, ybmclient.ENTITYTYPEENUM_CLUSTER, ybmclient.TASKTYPEENUM_DELETE_CLUSTER, []string{"FAILED", "SUCCEEDED"}, msg, 1800)
 			if err != nil {
 				logrus.Fatalf("error when getting task status: %s", err)
 			}

--- a/cmd/cluster/network/nal/assign_nal_cluster.go
+++ b/cmd/cluster/network/nal/assign_nal_cluster.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/viper"
 	ybmAuthClient "github.com/yugabyte/ybm-cli/internal/client"
 	"github.com/yugabyte/ybm-cli/internal/formatter"
+	ybmclient "github.com/yugabyte/yugabytedb-managed-go-client-internal"
 )
 
 // assignClusterCmd represents the cluster command
@@ -68,7 +69,7 @@ var assignClusterCmd = &cobra.Command{
 		msg := fmt.Sprintf("The network allow list %s is being assigned to the cluster %s", formatter.Colorize(newNetworkAllowListName, formatter.GREEN_COLOR), formatter.Colorize(clusterName, formatter.GREEN_COLOR))
 
 		if viper.GetBool("wait") {
-			returnStatus, err := authApi.WaitForTaskCompletion(clusterId, "CLUSTER", "EDIT_ALLOW_LIST", []string{"FAILED", "SUCCEEDED"}, msg, 600)
+			returnStatus, err := authApi.WaitForTaskCompletion(clusterId, ybmclient.ENTITYTYPEENUM_CLUSTER, ybmclient.TASKTYPEENUM_EDIT_ALLOW_LIST, []string{"FAILED", "SUCCEEDED"}, msg, 600)
 			if err != nil {
 				logrus.Fatalf("error when getting task status: %s", err)
 			}

--- a/cmd/cluster/network/nal/unassign_nal_cluster.go
+++ b/cmd/cluster/network/nal/unassign_nal_cluster.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/viper"
 	ybmAuthClient "github.com/yugabyte/ybm-cli/internal/client"
 	"github.com/yugabyte/ybm-cli/internal/formatter"
+	ybmclient "github.com/yugabyte/yugabytedb-managed-go-client-internal"
 )
 
 // unassignClusterCmd represents the cluster command
@@ -76,7 +77,7 @@ var unassignClusterCmd = &cobra.Command{
 		msg := fmt.Sprintf("The network allow list %s is being unassigned from the cluster %s", formatter.Colorize(newNetworkAllowListName, formatter.GREEN_COLOR), formatter.Colorize(clusterName, formatter.GREEN_COLOR))
 
 		if viper.GetBool("wait") {
-			returnStatus, err := authApi.WaitForTaskCompletion(clusterId, "CLUSTER", "EDIT_ALLOW_LIST", []string{"FAILED", "SUCCEEDED"}, msg, 600)
+			returnStatus, err := authApi.WaitForTaskCompletion(clusterId, ybmclient.ENTITYTYPEENUM_CLUSTER, ybmclient.TASKTYPEENUM_EDIT_ALLOW_LIST, []string{"FAILED", "SUCCEEDED"}, msg, 600)
 			if err != nil {
 				logrus.Fatalf("error when getting task status: %s", err)
 			}

--- a/cmd/cluster/pause_cluster.go
+++ b/cmd/cluster/pause_cluster.go
@@ -54,7 +54,7 @@ var pauseClusterCmd = &cobra.Command{
 		msg := fmt.Sprintf("The cluster %s is being paused", formatter.Colorize(clusterName, formatter.GREEN_COLOR))
 
 		if viper.GetBool("wait") {
-			returnStatus, err := authApi.WaitForTaskCompletion(clusterID, "CLUSTER", "PAUSE_CLUSTER", []string{"FAILED", "SUCCEEDED"}, msg, 600)
+			returnStatus, err := authApi.WaitForTaskCompletion(clusterID, ybmclient.ENTITYTYPEENUM_CLUSTER, ybmclient.TASKTYPEENUM_PAUSE_CLUSTER, []string{"FAILED", "SUCCEEDED"}, msg, 600)
 			if err != nil {
 				logrus.Fatalf("error when getting task status: %s", err)
 			}

--- a/cmd/cluster/read-replica/read_replica.go
+++ b/cmd/cluster/read-replica/read_replica.go
@@ -250,7 +250,7 @@ var createReadReplicaCmd = &cobra.Command{
 		msg := fmt.Sprintf("Read Replica is being created for cluster %s", formatter.Colorize(ClusterName, formatter.GREEN_COLOR))
 
 		if viper.GetBool("wait") {
-			returnStatus, err := authApi.WaitForTaskCompletion(clusterID, "CLUSTER", "CREATE_READ_REPLICA", []string{"FAILED", "SUCCEEDED"}, msg, 1800)
+			returnStatus, err := authApi.WaitForTaskCompletion(clusterID, ybmclient.ENTITYTYPEENUM_CLUSTER, ybmclient.TASKTYPEENUM_CREATE_READ_REPLICA, []string{"FAILED", "SUCCEEDED"}, msg, 1800)
 			if err != nil {
 				logrus.Fatalf("error when getting task status: %s", err)
 			}
@@ -313,7 +313,7 @@ var updateReadReplicaCmd = &cobra.Command{
 		msg := fmt.Sprintf("Read Replica is being updated for cluster %s", formatter.Colorize(ClusterName, formatter.GREEN_COLOR))
 
 		if viper.GetBool("wait") {
-			returnStatus, err := authApi.WaitForTaskCompletion(clusterID, "CLUSTER", "EDIT_READ_REPLICA", []string{"FAILED", "SUCCEEDED"}, msg, 1800)
+			returnStatus, err := authApi.WaitForTaskCompletion(clusterID, ybmclient.ENTITYTYPEENUM_CLUSTER, ybmclient.TASKTYPEENUM_EDIT_READ_REPLICA, []string{"FAILED", "SUCCEEDED"}, msg, 1800)
 			if err != nil {
 				logrus.Fatalf("error when getting task status: %s", err)
 			}
@@ -356,7 +356,7 @@ var deleteReadReplicaCmd = &cobra.Command{
 		msg := fmt.Sprintf("Read Replica is being deleted for cluster %s", formatter.Colorize(ClusterName, formatter.GREEN_COLOR))
 
 		if viper.GetBool("wait") {
-			returnStatus, err := authApi.WaitForTaskCompletion(clusterID, "CLUSTER", "DELETE_READ_REPLICA", []string{"FAILED", "SUCCEEDED"}, msg, 1800)
+			returnStatus, err := authApi.WaitForTaskCompletion(clusterID, ybmclient.ENTITYTYPEENUM_CLUSTER, ybmclient.TASKTYPEENUM_DELETE_READ_REPLICA, []string{"FAILED", "SUCCEEDED"}, msg, 1800)
 			if err != nil {
 				logrus.Fatalf("error when getting task status: %s", err)
 			}

--- a/cmd/cluster/resume_cluster.go
+++ b/cmd/cluster/resume_cluster.go
@@ -54,7 +54,7 @@ var resumeClusterCmd = &cobra.Command{
 		msg := fmt.Sprintf("The cluster %s is being resumed", formatter.Colorize(clusterName, formatter.GREEN_COLOR))
 
 		if viper.GetBool("wait") {
-			returnStatus, err := authApi.WaitForTaskCompletion(clusterID, "CLUSTER", "RESUME_CLUSTER", []string{"FAILED", "SUCCEEDED"}, msg, 600)
+			returnStatus, err := authApi.WaitForTaskCompletion(clusterID, ybmclient.ENTITYTYPEENUM_CLUSTER, ybmclient.TASKTYPEENUM_RESUME_CLUSTER, []string{"FAILED", "SUCCEEDED"}, msg, 600)
 			if err != nil {
 				logrus.Fatalf("error when getting task status: %s", err)
 			}

--- a/cmd/cluster/update_cluster.go
+++ b/cmd/cluster/update_cluster.go
@@ -126,7 +126,7 @@ var updateClusterCmd = &cobra.Command{
 		msg := fmt.Sprintf("The cluster %s is being updated", formatter.Colorize(clusterName, formatter.GREEN_COLOR))
 
 		if viper.GetBool("wait") {
-			returnStatus, err := authApi.WaitForTaskCompletion(clusterID, "CLUSTER", "EDIT_CLUSTER", []string{"FAILED", "SUCCEEDED"}, msg, 1800)
+			returnStatus, err := authApi.WaitForTaskCompletion(clusterID, ybmclient.ENTITYTYPEENUM_CLUSTER, ybmclient.TASKTYPEENUM_EDIT_CLUSTER, []string{"FAILED", "SUCCEEDED"}, msg, 1800)
 			if err != nil {
 				logrus.Fatalf("error when getting task status: %s", err)
 			}

--- a/cmd/vpc/peering/vpc_peering.go
+++ b/cmd/vpc/peering/vpc_peering.go
@@ -195,7 +195,7 @@ var createVpcPeeringCmd = &cobra.Command{
 		msg := fmt.Sprintf("The VPC Peering %s is being created", formatter.Colorize(vpcPeeringName, formatter.GREEN_COLOR))
 
 		if viper.GetBool("wait") {
-			returnStatus, err := authApi.WaitForTaskCompletion(ybVpcId, "", "CREATE_VPC_PEERING", []string{"FAILED", "SUCCEEDED"}, msg, 1800)
+			returnStatus, err := authApi.WaitForTaskCompletion(ybVpcId, "", ybmclient.TASKTYPEENUM_CREATE_VPC_PEERING, []string{"FAILED", "SUCCEEDED"}, msg, 1800)
 			if err != nil {
 				logrus.Fatalf("error when getting task status: %s", err)
 			}
@@ -258,7 +258,7 @@ var deleteVpcPeeringCmd = &cobra.Command{
 		msg := fmt.Sprintf("VPC peering %s is being terminated", formatter.Colorize(vpcPeeringName, formatter.GREEN_COLOR))
 
 		if viper.GetBool("wait") {
-			returnStatus, err := authApi.WaitForTaskCompletion(ybvpcID, "", "DELETE_VPC_PEERING", []string{"FAILED", "SUCCEEDED"}, msg, 600)
+			returnStatus, err := authApi.WaitForTaskCompletion(ybvpcID, "", ybmclient.TASKTYPEENUM_DELETE_VPC_PEERING, []string{"FAILED", "SUCCEEDED"}, msg, 600)
 			if err != nil {
 				logrus.Fatalf("error when getting task status: %s", err)
 			}

--- a/cmd/vpc/vpc.go
+++ b/cmd/vpc/vpc.go
@@ -151,7 +151,7 @@ var createVpcCmd = &cobra.Command{
 		msg := fmt.Sprintf("The VPC %s is being created", formatter.Colorize(vpcName, formatter.GREEN_COLOR))
 
 		if viper.GetBool("wait") {
-			returnStatus, err := authApi.WaitForTaskCompletion(vpcID, "", "CREATE_VPC", []string{"FAILED", "SUCCEEDED"}, msg, 600)
+			returnStatus, err := authApi.WaitForTaskCompletion(vpcID, "", ybmclient.TASKTYPEENUM_CREATE_VPC, []string{"FAILED", "SUCCEEDED"}, msg, 600)
 			if err != nil {
 				logrus.Fatalf("error when getting task status: %s", err)
 			}
@@ -206,7 +206,7 @@ var deleteVpcCmd = &cobra.Command{
 		msg := fmt.Sprintf("The VPC %s is being deleted", formatter.Colorize(vpcName, formatter.GREEN_COLOR))
 
 		if viper.GetBool("wait") {
-			returnStatus, err := authApi.WaitForTaskCompletion(vpcId, "", "DELETE_VPC", []string{"FAILED", "SUCCEEDED"}, msg, 600)
+			returnStatus, err := authApi.WaitForTaskCompletion(vpcId, "", ybmclient.TASKTYPEENUM_DELETE_VPC, []string{"FAILED", "SUCCEEDED"}, msg, 600)
 			if err != nil {
 				logrus.Fatalf("error when getting task status: %s", err)
 			}

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.15.0
 	github.com/t-tomalak/logrus-easy-formatter v0.0.0-20190827215021-c074f06c5816
-	github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20230128004341-7bd09f253ed8
+	github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20230316062908-5b0566196202
 	golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2
 	golang.org/x/term v0.6.0
 	gotest.tools/v3 v3.4.0

--- a/go.sum
+++ b/go.sum
@@ -259,6 +259,8 @@ github.com/t-tomalak/logrus-easy-formatter v0.0.0-20190827215021-c074f06c5816 h1
 github.com/t-tomalak/logrus-easy-formatter v0.0.0-20190827215021-c074f06c5816/go.mod h1:tzym/CEb5jnFI+Q0k4Qq3+LvRF4gO3E2pxS8fHP8jcA=
 github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20230128004341-7bd09f253ed8 h1:mq9vH0tGfDNa0BQWiuQM0TJsA6wdxB8kHdkAROD8cYk=
 github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20230128004341-7bd09f253ed8/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20230316062908-5b0566196202 h1:wTAdnBa5Ksz60zoTuKEIuxGzc90CRjj25MeMNWA2NSg=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20230316062908-5b0566196202/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -661,7 +661,7 @@ func (a *AuthApiClient) ListTasks() ybmclient.ApiListTasksRequest {
 	return a.ApiClient.TaskApi.ListTasks(a.ctx, a.AccountID)
 }
 
-func (a *AuthApiClient) WaitForTaskCompletion(entityId string, entityType string, taskType string, completionStatus []string, message string, timeOutInSec int) (string, error) {
+func (a *AuthApiClient) WaitForTaskCompletion(entityId string, entityType ybmclient.EntityTypeEnum, taskType ybmclient.TaskTypeEnum, completionStatus []string, message string, timeOutInSec int) (string, error) {
 
 	if strings.ToLower(os.Getenv("YBM_CI")) == "true" {
 		return a.WaitForTaskCompletionCI(entityId, entityType, taskType, completionStatus, message, timeOutInSec)
@@ -670,7 +670,7 @@ func (a *AuthApiClient) WaitForTaskCompletion(entityId string, entityType string
 
 }
 
-func (a *AuthApiClient) WaitForTaskCompletionCI(entityId string, entityType string, taskType string, completionStatus []string, message string, timeOutInSec int) (string, error) {
+func (a *AuthApiClient) WaitForTaskCompletionCI(entityId string, entityType ybmclient.EntityTypeEnum, taskType ybmclient.TaskTypeEnum, completionStatus []string, message string, timeOutInSec int) (string, error) {
 	var taskList ybmclient.TaskListResponse
 	var resp *http.Response
 	var err error
@@ -725,7 +725,7 @@ func (a *AuthApiClient) WaitForTaskCompletionCI(entityId string, entityType stri
 
 }
 
-func (a *AuthApiClient) WaitForTaskCompletionFull(entityId string, entityType string, taskType string, completionStatus []string, message string, timeOutInSec int) (string, error) {
+func (a *AuthApiClient) WaitForTaskCompletionFull(entityId string, entityType ybmclient.EntityTypeEnum, taskType ybmclient.TaskTypeEnum, completionStatus []string, message string, timeOutInSec int) (string, error) {
 	var taskList ybmclient.TaskListResponse
 	var resp *http.Response
 	var err error


### PR DESCRIPTION
The task and entity types changed to ENUMs in the API server, hence we need to change it here as well when using the latest client.