### PR TITLE
PSE: Fix the case when securityPrincipals list is empty

### DIFF
--- a/cmd/cluster/network/endpoint/update_endpoint.go
+++ b/cmd/cluster/network/endpoint/update_endpoint.go
@@ -17,10 +17,10 @@ package endpoint
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/yugabyte/ybm-cli/cmd/util"
 	ybmAuthClient "github.com/yugabyte/ybm-cli/internal/client"
 	ybmclient "github.com/yugabyte/yugabytedb-managed-go-client-internal"
 )
@@ -58,7 +58,7 @@ var updateEndpointCmd = &cobra.Command{
 			}
 
 			securityPrincipalsString, _ := cmd.Flags().GetString("security-principals")
-			securityPrincipalsList := strings.Split(securityPrincipalsString, ",")
+			securityPrincipalsList := util.SplitAndIgnoreEmpty(securityPrincipalsString, ",")
 
 			regionArnMap := make(map[string][]string)
 			regionArnMap[pseGetResponse.Data.Spec.ClusterRegionInfoId] = securityPrincipalsList

--- a/cmd/util/util.go
+++ b/cmd/util/util.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strings"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -98,4 +99,15 @@ func Filter[T any](ss []T, test func(T) bool) (ret []T) {
 		}
 	}
 	return
+}
+
+func SplitAndIgnoreEmpty(str string, sep string) []string {
+	split := Filter(strings.Split(str, sep), func(s string) bool {
+		return s != ""
+	})
+	// If the string is empty, we want to return an empty slice
+	if split == nil {
+		return []string{}
+	}
+	return split
 }


### PR DESCRIPTION
In case the user specifies an empty string, we would also send an empty string
to the backend. This would result in an issue, as it expects the SP to be an ARN
for AWS.

I added a method that does a string split while ignoring the empty items (similar
to what `StringSplitOptions.RemoveEmptyEntries` does in C#).