### PR TITLE
Cache the latest release version locally 

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,7 +16,6 @@
 package cmd
 
 import (
-	"errors"
 	"os"
 	"strings"
 
@@ -79,6 +78,8 @@ func setDefaults() {
 	viper.SetDefault("debug", false)
 	viper.SetDefault("no-color", false)
 	viper.SetDefault("wait", false)
+	viper.SetDefault("lastVersionAvailable", "v0.0.0")
+	viper.SetDefault("lastCheckedTime", 0)
 }
 
 func init() {
@@ -88,8 +89,6 @@ func init() {
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
 	setDefaults()
-	// Create the file to cache the latest version of the YBM CLI
-	initLatestVersionFile()
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.ybm-cli.yaml)")
 	rootCmd.PersistentFlags().StringP("apiKey", "a", "", "YBM Api Key")
 	rootCmd.PersistentFlags().StringP("output", "o", "", "Select the desired output format (table, json, pretty). Default to table")
@@ -125,18 +124,6 @@ func init() {
 	rootCmd.AddCommand(region.CloudRegionsCmd)
 	util.AddCommandIfFeatureFlag(rootCmd, cdc.CdcCmd, util.CDC)
 
-}
-
-func initLatestVersionFile() {
-	// Create file to cache latest version of the YBM CLI
-	latestVersionFile, err := releases.GetLatestVersionFile()
-	cobra.CheckErr(err)
-	_, err = os.Stat(latestVersionFile)
-	if errors.Is(err, os.ErrNotExist) {
-		// Storing data in the format 'timestamp,version'
-		err = os.WriteFile(latestVersionFile, []byte("0,v0.0.0"), 0666)
-		cobra.CheckErr(err)
-	}
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,7 @@
 package cmd
 
 import (
+	"errors"
 	"os"
 	"strings"
 
@@ -57,6 +58,7 @@ var rootCmd = &cobra.Command{
 			return
 		}
 		releases.PrintUpgradeMessageIfNeeded()
+
 	},
 }
 
@@ -86,6 +88,8 @@ func init() {
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
 	setDefaults()
+	// Create the file to cache the latest version of the YBM CLI
+	initLatestVersionFile()
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.ybm-cli.yaml)")
 	rootCmd.PersistentFlags().StringP("apiKey", "a", "", "YBM Api Key")
 	rootCmd.PersistentFlags().StringP("output", "o", "", "Select the desired output format (table, json, pretty). Default to table")
@@ -121,6 +125,18 @@ func init() {
 	rootCmd.AddCommand(region.CloudRegionsCmd)
 	util.AddCommandIfFeatureFlag(rootCmd, cdc.CdcCmd, util.CDC)
 
+}
+
+func initLatestVersionFile() {
+	// Create file to cache latest version of the YBM CLI
+	latestVersionFile, err := releases.GetLatestVersionFile()
+	cobra.CheckErr(err)
+	_, err = os.Stat(latestVersionFile)
+	if errors.Is(err, os.ErrNotExist) {
+		// Storing data in the format 'timestamp,version'
+		err = os.WriteFile(latestVersionFile, []byte("0,v0.0.0"), 0666)
+		cobra.CheckErr(err)
+	}
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/internal/releases/releases_test.go
+++ b/internal/releases/releases_test.go
@@ -15,8 +15,12 @@
 package releases_test
 
 import (
+	"os"
+	"strconv"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/spf13/viper"
 	"github.com/yugabyte/ybm-cli/internal/log"
 	"github.com/yugabyte/ybm-cli/internal/releases"
 )
@@ -46,5 +50,122 @@ var _ = Describe("Releases", func() {
 			Entry("[vv1]Release 1 is greater than release 2", "vv1.2.3", "1.2.2", false),
 			Entry("[vv2]Release 1 is less than release 2", "1.2.3", "vv1.2.4", true),
 		)
+	})
+
+	Context("When fetching the latest releases from Github", func() {
+		It("should not fetch if the current timestamp is less than 24 hours from the existing timestamp", func() {
+			fetchFromGithub, err := releases.ShouldFetchLatestRelease("0", 3600)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fetchFromGithub).To(Equal(false))
+		})
+		It("fetch if the current timestamp is more than 24 hours from the existing timestamp", func() {
+			fetchFromGithub, err := releases.ShouldFetchLatestRelease("0", 3600*25)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fetchFromGithub).To(Equal(true))
+		})
+		It("Throw error if the timestamp contains a character", func() {
+			_, err := releases.ShouldFetchLatestRelease("0v", 3600*25)
+			Expect(err).To(HaveOccurred())
+		})
+		It("Throw error if the timestamp is null", func() {
+			_, err := releases.ShouldFetchLatestRelease("", 3600*25)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Context("When fetching the release config from viper", func() {
+		It("Fetch release config properly from viper", func() {
+			lastVersionAvailable := "v0.0.1"
+			lastCheckedTime := "10"
+			viper.GetViper().Set("lastVersionAvailable", &lastVersionAvailable)
+			viper.GetViper().Set("lastCheckedTime", &lastCheckedTime)
+			releaseConfig, err := releases.GetReleaseConfig()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(releaseConfig.LastVersionAvailable).To(Equal(lastVersionAvailable))
+			Expect(releaseConfig.LastCheckedTime).To(Equal(lastCheckedTime))
+		})
+		It("Fetch release config with invalid version", func() {
+			lastVersionAvailable := "0.0.1"
+			lastCheckedTime := "10"
+			viper.GetViper().Set("lastVersionAvailable", &lastVersionAvailable)
+			viper.GetViper().Set("lastCheckedTime", &lastCheckedTime)
+			_, err := releases.GetReleaseConfig()
+			Expect(err).To(HaveOccurred())
+		})
+		It("Fetch release config with null string as version", func() {
+			lastVersionAvailable := ""
+			lastCheckedTime := "10"
+			viper.GetViper().Set("lastVersionAvailable", &lastVersionAvailable)
+			viper.GetViper().Set("lastCheckedTime", &lastCheckedTime)
+			_, err := releases.GetReleaseConfig()
+			Expect(err).To(HaveOccurred())
+		})
+		It("Fetch release config with negative time", func() {
+			lastVersionAvailable := "v0.1.1"
+			lastCheckedTime := "-10"
+			viper.GetViper().Set("lastVersionAvailable", &lastVersionAvailable)
+			viper.GetViper().Set("lastCheckedTime", &lastCheckedTime)
+			_, err := releases.GetReleaseConfig()
+			Expect(err).To(HaveOccurred())
+		})
+		It("Fetch release config with time having a character", func() {
+			lastVersionAvailable := "v0.1.1"
+			lastCheckedTime := "10v"
+			viper.GetViper().Set("lastVersionAvailable", &lastVersionAvailable)
+			viper.GetViper().Set("lastCheckedTime", &lastCheckedTime)
+			_, err := releases.GetReleaseConfig()
+			Expect(err).To(HaveOccurred())
+		})
+		It("Fetch release config with time being a null string", func() {
+			lastVersionAvailable := "v0.1.1"
+			lastCheckedTime := ""
+			viper.GetViper().Set("lastVersionAvailable", &lastVersionAvailable)
+			viper.GetViper().Set("lastCheckedTime", &lastCheckedTime)
+			_, err := releases.GetReleaseConfig()
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Context("When writing release config to viper", func() {
+		It("Write release config to viper", func() {
+			version := "v0.0.1"
+			timestamp := 10
+			timestampString := strconv.Itoa(timestamp)
+			viper.SetConfigFile(".tmp")
+			viper.SetConfigType("yaml")
+			err := releases.WriteReleaseConfig(int64(timestamp), version)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(viper.GetString("lastCheckedTime")).To(Equal(timestampString))
+			Expect(viper.GetString("lastVersionAvailable")).To(Equal(version))
+			os.Remove(".tmp")
+		})
+		It("Write release config to viper with invalid version", func() {
+			version := "0.0.1"
+			timestamp := 10
+			viper.SetConfigFile(".tmp")
+			viper.SetConfigType("yaml")
+			err := releases.WriteReleaseConfig(int64(timestamp), version)
+			Expect(err).To(HaveOccurred())
+			os.Remove(".tmp")
+		})
+		It("Write release config to viper with null version", func() {
+			version := ""
+			timestamp := 10
+			viper.SetConfigFile(".tmp")
+			viper.SetConfigType("yaml")
+			err := releases.WriteReleaseConfig(int64(timestamp), version)
+			Expect(err).To(HaveOccurred())
+			os.Remove(".tmp")
+		})
+		It("Write release config to viper with negative timestamp", func() {
+			version := ""
+			timestamp := 10
+			viper.SetConfigFile(".tmp")
+			viper.SetConfigType("yaml")
+			err := releases.WriteReleaseConfig(int64(timestamp), version)
+			Expect(err).To(HaveOccurred())
+			os.Remove(".tmp")
+		})
+
 	})
 })


### PR DESCRIPTION
Currently we fetch the latest version of the CLI from Github releases for every execution of the YBM CLI. However, this can lead to a overwhelming number of calls to the Github API server during automation and other scenarios where the CLI is executed frequently leading to request denial from the Github API server. Therefore, the idea is to cache the latest version of YBM CLI from Github releases and fetch it only periodically from Github. 