### PR TITLE
Add documentations generating tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ test:
 	go get github.com/onsi/gomega/...
 	ginkgo run -r -v
 
+doc:
+	YBM_FF_TOOLS=true  go run main.go tools gen-doc --format markdown
 
 build:
 	go build -ldflags="-X 'main.version=v${VERSION}'" -o ${BINARY}

--- a/NOTICE
+++ b/NOTICE
@@ -59,6 +59,13 @@ The following subcomponents are used:
 * License: [MIT](https://github.com/common-nighthawk/go-figure/blob/734e95fb86be/LICENSE)
 
 
+## github.com/cpuguy83/go-md2man/v2/md2man
+
+* Name: github.com/cpuguy83/go-md2man/v2/md2man
+* Version: v2.0.2
+* License: [MIT](https://github.com/cpuguy83/go-md2man/blob/v2.0.2/LICENSE.md)
+
+
 ## github.com/enescakir/emoji
 
 * Name: github.com/enescakir/emoji
@@ -246,6 +253,13 @@ The following subcomponents are used:
 * Name: github.com/rivo/uniseg
 * Version: v0.4.4
 * License: [MIT](https://github.com/rivo/uniseg/blob/v0.4.4/LICENSE.txt)
+
+
+## github.com/russross/blackfriday/v2
+
+* Name: github.com/russross/blackfriday/v2
+* Version: v2.1.0
+* License: [BSD-2-Clause](https://github.com/russross/blackfriday/blob/v2.1.0/LICENSE.txt)
 
 
 ## github.com/shopspring/decimal

--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ just add it to the host `http://cloud.yugabyte.com`
 
 ![Demo of the CLI](./resources/demo.gif)
 
+## Commands list
+You can find all command documentation [here](./docs/ybm.md)
+
+
+
 ## Sample Commands:
 
 ### Cluster

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,6 +29,7 @@ import (
 	"github.com/yugabyte/ybm-cli/cmd/nal"
 	"github.com/yugabyte/ybm-cli/cmd/region"
 	"github.com/yugabyte/ybm-cli/cmd/signup"
+	"github.com/yugabyte/ybm-cli/cmd/tools"
 	"github.com/yugabyte/ybm-cli/cmd/util"
 	"github.com/yugabyte/ybm-cli/cmd/vpc"
 
@@ -122,6 +123,7 @@ func init() {
 	rootCmd.AddCommand(authCmd)
 	rootCmd.AddCommand(signup.SignUpCmd)
 	rootCmd.AddCommand(region.CloudRegionsCmd)
+	util.AddCommandIfFeatureFlag(rootCmd, tools.ToolsCmd, util.TOOLS)
 	util.AddCommandIfFeatureFlag(rootCmd, cdc.CdcCmd, util.CDC)
 
 }

--- a/cmd/tools/tools.go
+++ b/cmd/tools/tools.go
@@ -1,0 +1,76 @@
+// Licensed to Yugabyte, Inc. under one or more contributor license
+// agreements. See the NOTICE file distributed with this work for
+// additional information regarding copyright ownership. Yugabyte
+// licenses this file to you under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package tools
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/cobra/doc"
+	"github.com/spf13/viper"
+	"golang.org/x/exp/slices"
+)
+
+var documentationFormat = []string{"markdown", "yaml", "rest"}
+
+var ToolsCmd = &cobra.Command{
+	Use:   "tools",
+	Short: "Tools command",
+	Long:  "Differents tools for Yugabyte developer",
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Help()
+	},
+}
+
+var generateDocsCmd = &cobra.Command{
+	Use:   "gen-doc",
+	Short: "Generate docs",
+	PreRun: func(cmd *cobra.Command, args []string) {
+		if !slices.Contains(documentationFormat, viper.GetString("format")) {
+			log.Fatalf("format only accept %s as value", strings.Join(documentationFormat, ","))
+
+		}
+	},
+	Long: "Generate docs in differents format to stdin",
+	Run: func(cmd *cobra.Command, args []string) {
+		var err error
+		cmd.Root().DisableAutoGenTag = true
+		switch viper.GetString("format") {
+		case "markdown":
+			err = doc.GenMarkdownTree(cmd.Root(), "./docs")
+		case "yaml":
+			err = doc.GenYamlTree(cmd.Root(), "./docs")
+		case "rest":
+			err = doc.GenReSTTree(cmd.Root(), "./docs")
+		}
+		if err != nil {
+			log.Fatal(err)
+		}
+
+	},
+}
+
+func init() {
+	ToolsCmd.AddCommand(generateDocsCmd)
+
+	generateDocsCmd.Flags().SortFlags = false
+	generateDocsCmd.Flags().String("format", "", fmt.Sprintf("[Optional] Documentation output format (%s) .(Default markdown)", strings.Join(documentationFormat, ",")))
+	viper.BindPFlag("format", generateDocsCmd.Flags().Lookup("format"))
+	viper.SetDefault("format", "markdown")
+
+}

--- a/cmd/util/feature_flags.go
+++ b/cmd/util/feature_flags.go
@@ -28,6 +28,7 @@ const (
 	CDC           FeatureFlag = "CDC"
 	CONFIGURE_URL FeatureFlag = "CONFIGURE_URL"
 	NODE_OP       FeatureFlag = "NODE_OPS"
+	TOOLS         FeatureFlag = "TOOLS"
 )
 
 func (f FeatureFlag) String() string {

--- a/docs/ybm.md
+++ b/docs/ybm.md
@@ -1,0 +1,38 @@
+## ybm
+
+ybm - Effortlessly manage your DB infrastructure on YugabyteDB Managed (DBaaS) from command line!
+
+### Synopsis
+
+ybm - Effortlessly manage your DB infrastructure on YugabyteDB Managed (DBaaS) from command line!
+
+```
+ybm [flags]
+```
+
+### Options
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -h, --help              help for ybm
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+  -t, --toggle            Help message for toggle
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm auth](ybm_auth.md)	 - Authenticate ybm CLI
+* [ybm backup](ybm_backup.md)	 - Manage backup operations of a cluster
+* [ybm cluster](ybm_cluster.md)	 - Manage cluster operations
+* [ybm completion](ybm_completion.md)	 - Generate the autocompletion script for the specified shell
+* [ybm network-allow-list](ybm_network-allow-list.md)	 - Manage Network Allow Lists
+* [ybm region](ybm_region.md)	 - Manage cloud regions
+* [ybm signup](ybm_signup.md)	 - Open a browser to sign up for YugabyteDB Managed
+* [ybm tools](ybm_tools.md)	 - Tools command
+* [ybm vpc](ybm_vpc.md)	 - Manage VPCs
+

--- a/docs/ybm_auth.md
+++ b/docs/ybm_auth.md
@@ -1,0 +1,34 @@
+## ybm auth
+
+Authenticate ybm CLI
+
+### Synopsis
+
+Authenticate the ybm CLI through this command by providing the API Key.
+
+```
+ybm auth [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for auth
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm](ybm.md)	 - ybm - Effortlessly manage your DB infrastructure on YugabyteDB Managed (DBaaS) from command line!
+

--- a/docs/ybm_backup.md
+++ b/docs/ybm_backup.md
@@ -1,0 +1,39 @@
+## ybm backup
+
+Manage backup operations of a cluster
+
+### Synopsis
+
+Manage backup operations of a cluster
+
+```
+ybm backup [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for backup
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm](ybm.md)	 - ybm - Effortlessly manage your DB infrastructure on YugabyteDB Managed (DBaaS) from command line!
+* [ybm backup create](ybm_backup_create.md)	 - Create backup for a cluster in YugabyteDB Managed
+* [ybm backup delete](ybm_backup_delete.md)	 - Delete backup for a cluster in YugabyteDB Managed
+* [ybm backup get](ybm_backup_get.md)	 - Get list of existing backups available for a cluster in YugabyteDB Managed
+* [ybm backup list](ybm_backup_list.md)	 - List existing backups available for a cluster in YugabyteDB Managed
+* [ybm backup restore](ybm_backup_restore.md)	 - Restore backups into a cluster in YugabyteDB Managed
+

--- a/docs/ybm_backup_create.md
+++ b/docs/ybm_backup_create.md
@@ -1,0 +1,37 @@
+## ybm backup create
+
+Create backup for a cluster in YugabyteDB Managed
+
+### Synopsis
+
+Create backup for a cluster in YugabyteDB Managed
+
+```
+ybm backup create [flags]
+```
+
+### Options
+
+```
+      --cluster-name string      [REQUIRED] Name for the cluster.
+      --description string       [OPTIONAL] Description of the backup.
+  -h, --help                     help for create
+      --retention-period int32   [OPTIONAL] Retention period of the backup in days. (Default: 1)
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm backup](ybm_backup.md)	 - Manage backup operations of a cluster
+

--- a/docs/ybm_backup_delete.md
+++ b/docs/ybm_backup_delete.md
@@ -1,0 +1,35 @@
+## ybm backup delete
+
+Delete backup for a cluster in YugabyteDB Managed
+
+### Synopsis
+
+Delete backup for a cluster in YugabyteDB Managed
+
+```
+ybm backup delete [flags]
+```
+
+### Options
+
+```
+      --backup-id string   [REQUIRED] The backup ID.
+  -h, --help               help for delete
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm backup](ybm_backup.md)	 - Manage backup operations of a cluster
+

--- a/docs/ybm_backup_get.md
+++ b/docs/ybm_backup_get.md
@@ -1,0 +1,35 @@
+## ybm backup get
+
+Get list of existing backups available for a cluster in YugabyteDB Managed
+
+### Synopsis
+
+Get list of existing backups available for a cluster in YugabyteDB Managed
+
+```
+ybm backup get [flags]
+```
+
+### Options
+
+```
+      --cluster-name string   [OPTIONAL] Name of the cluster to fetch backups.
+  -h, --help                  help for get
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm backup](ybm_backup.md)	 - Manage backup operations of a cluster
+

--- a/docs/ybm_backup_list.md
+++ b/docs/ybm_backup_list.md
@@ -1,0 +1,35 @@
+## ybm backup list
+
+List existing backups available for a cluster in YugabyteDB Managed
+
+### Synopsis
+
+List existing backups available for a cluster in YugabyteDB Managed
+
+```
+ybm backup list [flags]
+```
+
+### Options
+
+```
+      --cluster-name string   [OPTIONAL] Name of the cluster to fetch backups.
+  -h, --help                  help for list
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm backup](ybm_backup.md)	 - Manage backup operations of a cluster
+

--- a/docs/ybm_backup_restore.md
+++ b/docs/ybm_backup_restore.md
@@ -1,0 +1,36 @@
+## ybm backup restore
+
+Restore backups into a cluster in YugabyteDB Managed
+
+### Synopsis
+
+Restore backups into a cluster in  YugabyteDB Managed
+
+```
+ybm backup restore [flags]
+```
+
+### Options
+
+```
+      --backup-id string      [REQUIRED] ID of the backup to be restored.
+      --cluster-name string   [REQUIRED] Name of the cluster to restore backups.
+  -h, --help                  help for restore
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm backup](ybm_backup.md)	 - Manage backup operations of a cluster
+

--- a/docs/ybm_cluster.md
+++ b/docs/ybm_cluster.md
@@ -1,0 +1,46 @@
+## ybm cluster
+
+Manage cluster operations
+
+### Synopsis
+
+Manage cluster operations
+
+```
+ybm cluster [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for cluster
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm](ybm.md)	 - ybm - Effortlessly manage your DB infrastructure on YugabyteDB Managed (DBaaS) from command line!
+* [ybm cluster cert](ybm_cluster_cert.md)	 - Get the root CA certificate
+* [ybm cluster create](ybm_cluster_create.md)	 - Create a cluster
+* [ybm cluster delete](ybm_cluster_delete.md)	 - Delete a cluster
+* [ybm cluster describe](ybm_cluster_describe.md)	 - Describe a cluster
+* [ybm cluster get](ybm_cluster_get.md)	 - Get clusters
+* [ybm cluster list](ybm_cluster_list.md)	 - List clusters
+* [ybm cluster network](ybm_cluster_network.md)	 - Manage network operations
+* [ybm cluster node](ybm_cluster_node.md)	 - Manage nodes for a cluster
+* [ybm cluster pause](ybm_cluster_pause.md)	 - Pause a cluster
+* [ybm cluster read-replica](ybm_cluster_read-replica.md)	 - Manage Read Replicas
+* [ybm cluster resume](ybm_cluster_resume.md)	 - Resume a cluster
+* [ybm cluster update](ybm_cluster_update.md)	 - Update a cluster
+

--- a/docs/ybm_cluster_cert.md
+++ b/docs/ybm_cluster_cert.md
@@ -1,0 +1,35 @@
+## ybm cluster cert
+
+Get the root CA certificate
+
+### Synopsis
+
+Get the root CA certificate for your YBM clusters
+
+```
+ybm cluster cert [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for cert
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm cluster](ybm_cluster.md)	 - Manage cluster operations
+* [ybm cluster cert download](ybm_cluster_cert_download.md)	 - Download the root CA certificate
+

--- a/docs/ybm_cluster_cert_download.md
+++ b/docs/ybm_cluster_cert_download.md
@@ -1,0 +1,36 @@
+## ybm cluster cert download
+
+Download the root CA certificate
+
+### Synopsis
+
+Download the root CA certificate
+
+```
+ybm cluster cert download [flags]
+```
+
+### Options
+
+```
+  -f, --force        [OPTIONAL] Overwrite the output file if it exists
+  -h, --help         help for download
+      --out string   [OPTIONAL] Output file name (default: stdout)
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm cluster cert](ybm_cluster_cert.md)	 - Get the root CA certificate
+

--- a/docs/ybm_cluster_create.md
+++ b/docs/ybm_cluster_create.md
@@ -1,0 +1,43 @@
+## ybm cluster create
+
+Create a cluster
+
+### Synopsis
+
+Create a cluster
+
+```
+ybm cluster create [flags]
+```
+
+### Options
+
+```
+      --cluster-name string          [REQUIRED] Name of the cluster.
+      --credentials stringToString   [REQUIRED] Credentials to login to the cluster. Please provide key value pairs username=<user-name>,password=<password>. (default [])
+      --cloud-provider string        [OPTIONAL] The cloud provider where database needs to be deployed. AWS or GCP. Default AWS.
+      --cluster-type string          [OPTIONAL] Cluster replication type. SYNCHRONOUS or GEO_PARTITIONED. Default SYNCHRONOUS.
+      --node-config stringToInt      [OPTIONAL] Configuration of the cluster nodes. Please provide key value pairs num-cores=<num-cores>,disk-size-gb=<disk-size-gb> as the value. If specified  num-cores is mandatory, disk-size-gb is optional. (default [])
+      --region-info stringArray      [OPTIONAL] Region information for the cluster. Please provide key value pairs region=<region-name>,num-nodes=<number-of-nodes>,vpc=<vpc-name> as the value. If specified, region and num-nodes are mandatory, vpc is optional. Information about multiple regions can be specified by using multiple --region-info arguments. Default if not specified is us-west-2 AWS region.
+      --cluster-tier string          [OPTIONAL] The tier of the cluster. Sandbox or Dedicated. Default Sandbox.
+      --fault-tolerance string       [OPTIONAL] The fault tolerance of the cluster. The possible values are NONE, ZONE and REGION. Default NONE.
+      --database-version string      [OPTIONAL] The database version of the cluster. Stable or Preview. Default depends on cluster tier, Sandbox is Preview, Dedicated is Stable.
+  -h, --help                         help for create
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm cluster](ybm_cluster.md)	 - Manage cluster operations
+

--- a/docs/ybm_cluster_delete.md
+++ b/docs/ybm_cluster_delete.md
@@ -1,0 +1,35 @@
+## ybm cluster delete
+
+Delete a cluster
+
+### Synopsis
+
+Delete a cluster
+
+```
+ybm cluster delete [flags]
+```
+
+### Options
+
+```
+      --cluster-name string   [REQUIRED] The name of the cluster to be deleted.
+  -h, --help                  help for delete
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm cluster](ybm_cluster.md)	 - Manage cluster operations
+

--- a/docs/ybm_cluster_describe.md
+++ b/docs/ybm_cluster_describe.md
@@ -1,0 +1,35 @@
+## ybm cluster describe
+
+Describe a cluster
+
+### Synopsis
+
+Describe a cluster in YugabyteDB Managed
+
+```
+ybm cluster describe [flags]
+```
+
+### Options
+
+```
+      --cluster-name string   [REQUIRED] The name of the cluster to get details.
+  -h, --help                  help for describe
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm cluster](ybm_cluster.md)	 - Manage cluster operations
+

--- a/docs/ybm_cluster_get.md
+++ b/docs/ybm_cluster_get.md
@@ -1,0 +1,35 @@
+## ybm cluster get
+
+Get clusters
+
+### Synopsis
+
+Get clusters
+
+```
+ybm cluster get [flags]
+```
+
+### Options
+
+```
+      --cluster-name string   [OPTIONAL] The name of the cluster to get details.
+  -h, --help                  help for get
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm cluster](ybm_cluster.md)	 - Manage cluster operations
+

--- a/docs/ybm_cluster_list.md
+++ b/docs/ybm_cluster_list.md
@@ -1,0 +1,34 @@
+## ybm cluster list
+
+List clusters
+
+### Synopsis
+
+List clusters in YugabyteDB Managed
+
+```
+ybm cluster list [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for list
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm cluster](ybm_cluster.md)	 - Manage cluster operations
+

--- a/docs/ybm_cluster_network.md
+++ b/docs/ybm_cluster_network.md
@@ -1,0 +1,37 @@
+## ybm cluster network
+
+Manage network operations
+
+### Synopsis
+
+Manage network operations for a cluster
+
+```
+ybm cluster network [flags]
+```
+
+### Options
+
+```
+  -c, --cluster-name string   [REQUIRED] The name of the cluster.
+  -h, --help                  help for network
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm cluster](ybm_cluster.md)	 - Manage cluster operations
+* [ybm cluster network allow-list](ybm_cluster_network_allow-list.md)	 - Manage network allow-list operations for a cluster
+* [ybm cluster network endpoint](ybm_cluster_network_endpoint.md)	 - Manage network endpoints for a cluster
+

--- a/docs/ybm_cluster_network_allow-list.md
+++ b/docs/ybm_cluster_network_allow-list.md
@@ -1,0 +1,37 @@
+## ybm cluster network allow-list
+
+Manage network allow-list operations for a cluster
+
+### Synopsis
+
+Manage network allow-list operations for a cluster
+
+```
+ybm cluster network allow-list [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for allow-list
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string         YBM Api Key
+  -c, --cluster-name string   [REQUIRED] The name of the cluster.
+      --config string         config file (default is $HOME/.ybm-cli.yaml)
+      --debug                 Use debug mode, same as --logLevel debug
+  -l, --logLevel string       Select the desired log level format(info). Default to info
+      --no-color              Disable colors in output , default to false
+  -o, --output string         Select the desired output format (table, json, pretty). Default to table
+      --wait                  Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm cluster network](ybm_cluster_network.md)	 - Manage network operations
+* [ybm cluster network allow-list assign](ybm_cluster_network_allow-list_assign.md)	 - Assign resources(e.g. network allow lists) to clusters
+* [ybm cluster network allow-list unassign](ybm_cluster_network_allow-list_unassign.md)	 - Unassign resources(e.g. network allow lists) to clusters
+

--- a/docs/ybm_cluster_network_allow-list_assign.md
+++ b/docs/ybm_cluster_network_allow-list_assign.md
@@ -1,0 +1,36 @@
+## ybm cluster network allow-list assign
+
+Assign resources(e.g. network allow lists) to clusters
+
+### Synopsis
+
+Assign resources(e.g. network allow lists) to clusters
+
+```
+ybm cluster network allow-list assign [flags]
+```
+
+### Options
+
+```
+  -h, --help                        help for assign
+      --network-allow-list string   [REQUIRED] The name of the network allow list to be assigned.
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string         YBM Api Key
+  -c, --cluster-name string   [REQUIRED] The name of the cluster.
+      --config string         config file (default is $HOME/.ybm-cli.yaml)
+      --debug                 Use debug mode, same as --logLevel debug
+  -l, --logLevel string       Select the desired log level format(info). Default to info
+      --no-color              Disable colors in output , default to false
+  -o, --output string         Select the desired output format (table, json, pretty). Default to table
+      --wait                  Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm cluster network allow-list](ybm_cluster_network_allow-list.md)	 - Manage network allow-list operations for a cluster
+

--- a/docs/ybm_cluster_network_allow-list_unassign.md
+++ b/docs/ybm_cluster_network_allow-list_unassign.md
@@ -1,0 +1,36 @@
+## ybm cluster network allow-list unassign
+
+Unassign resources(e.g. network allow lists) to clusters
+
+### Synopsis
+
+Unassign resources(e.g. network allow lists) to clusters
+
+```
+ybm cluster network allow-list unassign [flags]
+```
+
+### Options
+
+```
+  -h, --help                        help for unassign
+      --network-allow-list string   [REQUIRED] The name of the network allow list to be unassigned.
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string         YBM Api Key
+  -c, --cluster-name string   [REQUIRED] The name of the cluster.
+      --config string         config file (default is $HOME/.ybm-cli.yaml)
+      --debug                 Use debug mode, same as --logLevel debug
+  -l, --logLevel string       Select the desired log level format(info). Default to info
+      --no-color              Disable colors in output , default to false
+  -o, --output string         Select the desired output format (table, json, pretty). Default to table
+      --wait                  Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm cluster network allow-list](ybm_cluster_network_allow-list.md)	 - Manage network allow-list operations for a cluster
+

--- a/docs/ybm_cluster_network_endpoint.md
+++ b/docs/ybm_cluster_network_endpoint.md
@@ -1,0 +1,40 @@
+## ybm cluster network endpoint
+
+Manage network endpoints for a cluster
+
+### Synopsis
+
+Manage network endpoints for a cluster
+
+```
+ybm cluster network endpoint [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for endpoint
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string         YBM Api Key
+  -c, --cluster-name string   [REQUIRED] The name of the cluster.
+      --config string         config file (default is $HOME/.ybm-cli.yaml)
+      --debug                 Use debug mode, same as --logLevel debug
+  -l, --logLevel string       Select the desired log level format(info). Default to info
+      --no-color              Disable colors in output , default to false
+  -o, --output string         Select the desired output format (table, json, pretty). Default to table
+      --wait                  Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm cluster network](ybm_cluster_network.md)	 - Manage network operations
+* [ybm cluster network endpoint create](ybm_cluster_network_endpoint_create.md)	 - Create a new network endpoint for a cluster
+* [ybm cluster network endpoint delete](ybm_cluster_network_endpoint_delete.md)	 - Delete a network endpoint for a cluster
+* [ybm cluster network endpoint describe](ybm_cluster_network_endpoint_describe.md)	 - Describe a network endpoint for a cluster
+* [ybm cluster network endpoint list](ybm_cluster_network_endpoint_list.md)	 - List network endpoints for a cluster
+* [ybm cluster network endpoint update](ybm_cluster_network_endpoint_update.md)	 - Update a network endpoint for a cluster
+

--- a/docs/ybm_cluster_network_endpoint_create.md
+++ b/docs/ybm_cluster_network_endpoint_create.md
@@ -1,0 +1,38 @@
+## ybm cluster network endpoint create
+
+Create a new network endpoint for a cluster
+
+### Synopsis
+
+Create a new network endpoint for a cluster
+
+```
+ybm cluster network endpoint create [flags]
+```
+
+### Options
+
+```
+      --accessibility-type string    [REQUIRED] The accessibility of the endpoint. Valid options are PUBLIC, PRIVATE and PRIVATE_SERVICE_ENDPOINT.
+  -h, --help                         help for create
+      --region string                [REQUIRED] The region of the endpoint.
+      --security-principals string   [OPTIONAL] The list of security principals that have access to this endpoint. Required for private service endpoints.  Accepts a comma separated list. E.g.: arn:aws:iam::account_id1:root,arn:aws:iam::account_id2:root
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string         YBM Api Key
+  -c, --cluster-name string   [REQUIRED] The name of the cluster.
+      --config string         config file (default is $HOME/.ybm-cli.yaml)
+      --debug                 Use debug mode, same as --logLevel debug
+  -l, --logLevel string       Select the desired log level format(info). Default to info
+      --no-color              Disable colors in output , default to false
+  -o, --output string         Select the desired output format (table, json, pretty). Default to table
+      --wait                  Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm cluster network endpoint](ybm_cluster_network_endpoint.md)	 - Manage network endpoints for a cluster
+

--- a/docs/ybm_cluster_network_endpoint_delete.md
+++ b/docs/ybm_cluster_network_endpoint_delete.md
@@ -1,0 +1,36 @@
+## ybm cluster network endpoint delete
+
+Delete a network endpoint for a cluster
+
+### Synopsis
+
+Delete a network endpoint for a cluster
+
+```
+ybm cluster network endpoint delete [flags]
+```
+
+### Options
+
+```
+      --endpoint-id string   [REQUIRED] THe ID of the endpoint
+  -h, --help                 help for delete
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string         YBM Api Key
+  -c, --cluster-name string   [REQUIRED] The name of the cluster.
+      --config string         config file (default is $HOME/.ybm-cli.yaml)
+      --debug                 Use debug mode, same as --logLevel debug
+  -l, --logLevel string       Select the desired log level format(info). Default to info
+      --no-color              Disable colors in output , default to false
+  -o, --output string         Select the desired output format (table, json, pretty). Default to table
+      --wait                  Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm cluster network endpoint](ybm_cluster_network_endpoint.md)	 - Manage network endpoints for a cluster
+

--- a/docs/ybm_cluster_network_endpoint_describe.md
+++ b/docs/ybm_cluster_network_endpoint_describe.md
@@ -1,0 +1,36 @@
+## ybm cluster network endpoint describe
+
+Describe a network endpoint for a cluster
+
+### Synopsis
+
+Describe a network endpoint for a cluster
+
+```
+ybm cluster network endpoint describe [flags]
+```
+
+### Options
+
+```
+      --endpoint-id string   [REQUIRED] The ID of the endpoint
+  -h, --help                 help for describe
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string         YBM Api Key
+  -c, --cluster-name string   [REQUIRED] The name of the cluster.
+      --config string         config file (default is $HOME/.ybm-cli.yaml)
+      --debug                 Use debug mode, same as --logLevel debug
+  -l, --logLevel string       Select the desired log level format(info). Default to info
+      --no-color              Disable colors in output , default to false
+  -o, --output string         Select the desired output format (table, json, pretty). Default to table
+      --wait                  Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm cluster network endpoint](ybm_cluster_network_endpoint.md)	 - Manage network endpoints for a cluster
+

--- a/docs/ybm_cluster_network_endpoint_list.md
+++ b/docs/ybm_cluster_network_endpoint_list.md
@@ -1,0 +1,37 @@
+## ybm cluster network endpoint list
+
+List network endpoints for a cluster
+
+### Synopsis
+
+List network endpoints for a cluster
+
+```
+ybm cluster network endpoint list [flags]
+```
+
+### Options
+
+```
+      --accessibility-type string   [OPTIONAL] Accessibility of the endpoint. Valid options are PUBLIC, PRIVATE and PRIVATE_SERVICE_ENDPOINT.
+  -h, --help                        help for list
+      --region string               [OPTIONAL] The region of the endpoint.
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string         YBM Api Key
+  -c, --cluster-name string   [REQUIRED] The name of the cluster.
+      --config string         config file (default is $HOME/.ybm-cli.yaml)
+      --debug                 Use debug mode, same as --logLevel debug
+  -l, --logLevel string       Select the desired log level format(info). Default to info
+      --no-color              Disable colors in output , default to false
+  -o, --output string         Select the desired output format (table, json, pretty). Default to table
+      --wait                  Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm cluster network endpoint](ybm_cluster_network_endpoint.md)	 - Manage network endpoints for a cluster
+

--- a/docs/ybm_cluster_network_endpoint_update.md
+++ b/docs/ybm_cluster_network_endpoint_update.md
@@ -1,0 +1,37 @@
+## ybm cluster network endpoint update
+
+Update a network endpoint for a cluster
+
+### Synopsis
+
+Update a network endpoint for a cluster
+
+```
+ybm cluster network endpoint update [flags]
+```
+
+### Options
+
+```
+      --endpoint-id string           [REQUIRED] The ID of the endpoint
+  -h, --help                         help for update
+      --security-principals string   [OPTIONAL] The list of security principals that have access to this endpoint. Required for private service endpoints.  Accepts a comma separated list. E.g.: arn:aws:iam::account_id1:root,arn:aws:iam::account_id2:root
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string         YBM Api Key
+  -c, --cluster-name string   [REQUIRED] The name of the cluster.
+      --config string         config file (default is $HOME/.ybm-cli.yaml)
+      --debug                 Use debug mode, same as --logLevel debug
+  -l, --logLevel string       Select the desired log level format(info). Default to info
+      --no-color              Disable colors in output , default to false
+  -o, --output string         Select the desired output format (table, json, pretty). Default to table
+      --wait                  Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm cluster network endpoint](ybm_cluster_network_endpoint.md)	 - Manage network endpoints for a cluster
+

--- a/docs/ybm_cluster_node.md
+++ b/docs/ybm_cluster_node.md
@@ -1,0 +1,35 @@
+## ybm cluster node
+
+Manage nodes for a cluster
+
+### Synopsis
+
+Manage nodes for a cluster
+
+```
+ybm cluster node [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for node
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm cluster](ybm_cluster.md)	 - Manage cluster operations
+* [ybm cluster node list](ybm_cluster_node_list.md)	 - List nodes for a cluster
+

--- a/docs/ybm_cluster_node_list.md
+++ b/docs/ybm_cluster_node_list.md
@@ -1,0 +1,35 @@
+## ybm cluster node list
+
+List nodes for a cluster
+
+### Synopsis
+
+List nodes for a cluster
+
+```
+ybm cluster node list [flags]
+```
+
+### Options
+
+```
+      --cluster-name string   [REQUIRED] The name of the cluster to get details.
+  -h, --help                  help for list
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm cluster node](ybm_cluster_node.md)	 - Manage nodes for a cluster
+

--- a/docs/ybm_cluster_pause.md
+++ b/docs/ybm_cluster_pause.md
@@ -1,0 +1,35 @@
+## ybm cluster pause
+
+Pause a cluster
+
+### Synopsis
+
+Pause a cluster
+
+```
+ybm cluster pause [flags]
+```
+
+### Options
+
+```
+      --cluster-name string   [REQUIRED] The name of the cluster to be paused.
+  -h, --help                  help for pause
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm cluster](ybm_cluster.md)	 - Manage cluster operations
+

--- a/docs/ybm_cluster_read-replica.md
+++ b/docs/ybm_cluster_read-replica.md
@@ -1,0 +1,40 @@
+## ybm cluster read-replica
+
+Manage Read Replicas
+
+### Synopsis
+
+Manage Read Replicas
+
+```
+ybm cluster read-replica [flags]
+```
+
+### Options
+
+```
+  -c, --cluster-name string   [REQUIRED] The name of the cluster.
+  -h, --help                  help for read-replica
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm cluster](ybm_cluster.md)	 - Manage cluster operations
+* [ybm cluster read-replica create](ybm_cluster_read-replica_create.md)	 - Create read replica
+* [ybm cluster read-replica delete](ybm_cluster_read-replica_delete.md)	 - Delete read replica
+* [ybm cluster read-replica get](ybm_cluster_read-replica_get.md)	 - Get read replica
+* [ybm cluster read-replica list](ybm_cluster_read-replica_list.md)	 - List read replicas
+* [ybm cluster read-replica update](ybm_cluster_read-replica_update.md)	 - Edit read replica
+

--- a/docs/ybm_cluster_read-replica_create.md
+++ b/docs/ybm_cluster_read-replica_create.md
@@ -1,0 +1,36 @@
+## ybm cluster read-replica create
+
+Create read replica
+
+### Synopsis
+
+Create read replica in YugabyteDB Managed
+
+```
+ybm cluster read-replica create [flags]
+```
+
+### Options
+
+```
+  -h, --help                  help for create
+  -r, --replica stringArray   [OPTIONAL] Region information for the cluster. Please provide key value pairs num-cores=<num-cores>,disk-size-gb=<disk-size-gb>,cloud-provider=<GCP or AWS>,region=<region>,num-nodes=<num-nodes>,vpc=<vpc-name>,num-replicas=<num-replicas>,multi-zone=<multi-zone>.
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string         YBM Api Key
+  -c, --cluster-name string   [REQUIRED] The name of the cluster.
+      --config string         config file (default is $HOME/.ybm-cli.yaml)
+      --debug                 Use debug mode, same as --logLevel debug
+  -l, --logLevel string       Select the desired log level format(info). Default to info
+      --no-color              Disable colors in output , default to false
+  -o, --output string         Select the desired output format (table, json, pretty). Default to table
+      --wait                  Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm cluster read-replica](ybm_cluster_read-replica.md)	 - Manage Read Replicas
+

--- a/docs/ybm_cluster_read-replica_delete.md
+++ b/docs/ybm_cluster_read-replica_delete.md
@@ -1,0 +1,35 @@
+## ybm cluster read-replica delete
+
+Delete read replica
+
+### Synopsis
+
+Delete read replica from YugabyteDB Managed
+
+```
+ybm cluster read-replica delete [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for delete
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string         YBM Api Key
+  -c, --cluster-name string   [REQUIRED] The name of the cluster.
+      --config string         config file (default is $HOME/.ybm-cli.yaml)
+      --debug                 Use debug mode, same as --logLevel debug
+  -l, --logLevel string       Select the desired log level format(info). Default to info
+      --no-color              Disable colors in output , default to false
+  -o, --output string         Select the desired output format (table, json, pretty). Default to table
+      --wait                  Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm cluster read-replica](ybm_cluster_read-replica.md)	 - Manage Read Replicas
+

--- a/docs/ybm_cluster_read-replica_get.md
+++ b/docs/ybm_cluster_read-replica_get.md
@@ -1,0 +1,35 @@
+## ybm cluster read-replica get
+
+Get read replica
+
+### Synopsis
+
+Get read replica in YugabyteDB Managed
+
+```
+ybm cluster read-replica get [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for get
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string         YBM Api Key
+  -c, --cluster-name string   [REQUIRED] The name of the cluster.
+      --config string         config file (default is $HOME/.ybm-cli.yaml)
+      --debug                 Use debug mode, same as --logLevel debug
+  -l, --logLevel string       Select the desired log level format(info). Default to info
+      --no-color              Disable colors in output , default to false
+  -o, --output string         Select the desired output format (table, json, pretty). Default to table
+      --wait                  Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm cluster read-replica](ybm_cluster_read-replica.md)	 - Manage Read Replicas
+

--- a/docs/ybm_cluster_read-replica_list.md
+++ b/docs/ybm_cluster_read-replica_list.md
@@ -1,0 +1,35 @@
+## ybm cluster read-replica list
+
+List read replicas
+
+### Synopsis
+
+List read replicas in YugabyteDB Managed
+
+```
+ybm cluster read-replica list [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for list
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string         YBM Api Key
+  -c, --cluster-name string   [REQUIRED] The name of the cluster.
+      --config string         config file (default is $HOME/.ybm-cli.yaml)
+      --debug                 Use debug mode, same as --logLevel debug
+  -l, --logLevel string       Select the desired log level format(info). Default to info
+      --no-color              Disable colors in output , default to false
+  -o, --output string         Select the desired output format (table, json, pretty). Default to table
+      --wait                  Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm cluster read-replica](ybm_cluster_read-replica.md)	 - Manage Read Replicas
+

--- a/docs/ybm_cluster_read-replica_update.md
+++ b/docs/ybm_cluster_read-replica_update.md
@@ -1,0 +1,36 @@
+## ybm cluster read-replica update
+
+Edit read replica
+
+### Synopsis
+
+Edit read replica in YugabyteDB Managed
+
+```
+ybm cluster read-replica update [flags]
+```
+
+### Options
+
+```
+  -h, --help                  help for update
+  -r, --replica stringArray   [OPTIONAL] Region information for the cluster. Please provide key value pairs num-cores=<num-cores>,disk-size-gb=<disk-size-gb>,cloud-provider=<GCP or AWS>,region=<region>,num-nodes=<num-nodes>,vpc=<vpc-name>,num-replicas=<num-replicas>,multi-zone=<multi-zone>.
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string         YBM Api Key
+  -c, --cluster-name string   [REQUIRED] The name of the cluster.
+      --config string         config file (default is $HOME/.ybm-cli.yaml)
+      --debug                 Use debug mode, same as --logLevel debug
+  -l, --logLevel string       Select the desired log level format(info). Default to info
+      --no-color              Disable colors in output , default to false
+  -o, --output string         Select the desired output format (table, json, pretty). Default to table
+      --wait                  Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm cluster read-replica](ybm_cluster_read-replica.md)	 - Manage Read Replicas
+

--- a/docs/ybm_cluster_resume.md
+++ b/docs/ybm_cluster_resume.md
@@ -1,0 +1,35 @@
+## ybm cluster resume
+
+Resume a cluster
+
+### Synopsis
+
+Resume a cluster
+
+```
+ybm cluster resume [flags]
+```
+
+### Options
+
+```
+      --cluster-name string   [REQUIRED] The name of the cluster to be resumed.
+  -h, --help                  help for resume
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm cluster](ybm_cluster.md)	 - Manage cluster operations
+

--- a/docs/ybm_cluster_update.md
+++ b/docs/ybm_cluster_update.md
@@ -1,0 +1,43 @@
+## ybm cluster update
+
+Update a cluster
+
+### Synopsis
+
+Update a cluster
+
+```
+ybm cluster update [flags]
+```
+
+### Options
+
+```
+      --cloud-provider string     [OPTIONAL] The cloud provider where database needs to be deployed. AWS or GCP.
+      --cluster-name string       [REQUIRED] Name of the cluster.
+      --cluster-tier string       [OPTIONAL] The tier of the cluster. Sandbox or Dedicated.
+      --cluster-type string       [OPTIONAL] Cluster replication type. SYNCHRONOUS or GEO_PARTITIONED.
+      --database-version string   [OPTIONAL] The database version of the cluster. Stable or Preview.
+      --fault-tolerance string    [OPTIONAL] The fault tolerance of the cluster. The possible values are NONE, ZONE and REGION.
+  -h, --help                      help for update
+      --new-name string           [OPTIONAL] The new name to be given to the cluster.
+      --node-config stringToInt   [OPTIONAL] Configuration of the cluster nodes. Please provide key value pairs num-cores=<num-cores>,disk-size-gb=<disk-size-gb> as the value.  num-cores is mandatory, disk-size-gb is optional. (default [])
+      --region-info stringArray   [OPTIONAL] Region information for the cluster. Please provide key value pairs, region=<region-name>,num-nodes=<number-of-nodes>,vpc=<vpc-name> as the value. If provided, region and num-nodes are mandatory, vpc is optional.
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm cluster](ybm_cluster.md)	 - Manage cluster operations
+

--- a/docs/ybm_completion.md
+++ b/docs/ybm_completion.md
@@ -1,0 +1,36 @@
+## ybm completion
+
+Generate the autocompletion script for the specified shell
+
+### Synopsis
+
+Generate the autocompletion script for ybm for the specified shell.
+See each sub-command's help for details on how to use the generated script.
+
+
+### Options
+
+```
+  -h, --help   help for completion
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm](ybm.md)	 - ybm - Effortlessly manage your DB infrastructure on YugabyteDB Managed (DBaaS) from command line!
+* [ybm completion bash](ybm_completion_bash.md)	 - Generate the autocompletion script for bash
+* [ybm completion fish](ybm_completion_fish.md)	 - Generate the autocompletion script for fish
+* [ybm completion powershell](ybm_completion_powershell.md)	 - Generate the autocompletion script for powershell
+* [ybm completion zsh](ybm_completion_zsh.md)	 - Generate the autocompletion script for zsh
+

--- a/docs/ybm_completion_bash.md
+++ b/docs/ybm_completion_bash.md
@@ -1,0 +1,55 @@
+## ybm completion bash
+
+Generate the autocompletion script for bash
+
+### Synopsis
+
+Generate the autocompletion script for the bash shell.
+
+This script depends on the 'bash-completion' package.
+If it is not installed already, you can install it via your OS's package manager.
+
+To load completions in your current shell session:
+
+	source <(ybm completion bash)
+
+To load completions for every new session, execute once:
+
+#### Linux:
+
+	ybm completion bash > /etc/bash_completion.d/ybm
+
+#### macOS:
+
+	ybm completion bash > $(brew --prefix)/etc/bash_completion.d/ybm
+
+You will need to start a new shell for this setup to take effect.
+
+
+```
+ybm completion bash
+```
+
+### Options
+
+```
+  -h, --help              help for bash
+      --no-descriptions   disable completion descriptions
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm completion](ybm_completion.md)	 - Generate the autocompletion script for the specified shell
+

--- a/docs/ybm_completion_fish.md
+++ b/docs/ybm_completion_fish.md
@@ -1,0 +1,46 @@
+## ybm completion fish
+
+Generate the autocompletion script for fish
+
+### Synopsis
+
+Generate the autocompletion script for the fish shell.
+
+To load completions in your current shell session:
+
+	ybm completion fish | source
+
+To load completions for every new session, execute once:
+
+	ybm completion fish > ~/.config/fish/completions/ybm.fish
+
+You will need to start a new shell for this setup to take effect.
+
+
+```
+ybm completion fish [flags]
+```
+
+### Options
+
+```
+  -h, --help              help for fish
+      --no-descriptions   disable completion descriptions
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm completion](ybm_completion.md)	 - Generate the autocompletion script for the specified shell
+

--- a/docs/ybm_completion_powershell.md
+++ b/docs/ybm_completion_powershell.md
@@ -1,0 +1,43 @@
+## ybm completion powershell
+
+Generate the autocompletion script for powershell
+
+### Synopsis
+
+Generate the autocompletion script for powershell.
+
+To load completions in your current shell session:
+
+	ybm completion powershell | Out-String | Invoke-Expression
+
+To load completions for every new session, add the output of the above command
+to your powershell profile.
+
+
+```
+ybm completion powershell [flags]
+```
+
+### Options
+
+```
+  -h, --help              help for powershell
+      --no-descriptions   disable completion descriptions
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm completion](ybm_completion.md)	 - Generate the autocompletion script for the specified shell
+

--- a/docs/ybm_completion_zsh.md
+++ b/docs/ybm_completion_zsh.md
@@ -1,0 +1,57 @@
+## ybm completion zsh
+
+Generate the autocompletion script for zsh
+
+### Synopsis
+
+Generate the autocompletion script for the zsh shell.
+
+If shell completion is not already enabled in your environment you will need
+to enable it.  You can execute the following once:
+
+	echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+To load completions in your current shell session:
+
+	source <(ybm completion zsh); compdef _ybm ybm
+
+To load completions for every new session, execute once:
+
+#### Linux:
+
+	ybm completion zsh > "${fpath[1]}/_ybm"
+
+#### macOS:
+
+	ybm completion zsh > $(brew --prefix)/share/zsh/site-functions/_ybm
+
+You will need to start a new shell for this setup to take effect.
+
+
+```
+ybm completion zsh [flags]
+```
+
+### Options
+
+```
+  -h, --help              help for zsh
+      --no-descriptions   disable completion descriptions
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm completion](ybm_completion.md)	 - Generate the autocompletion script for the specified shell
+

--- a/docs/ybm_network-allow-list.md
+++ b/docs/ybm_network-allow-list.md
@@ -1,0 +1,38 @@
+## ybm network-allow-list
+
+Manage Network Allow Lists
+
+### Synopsis
+
+Manage Network ALlow Lists
+
+```
+ybm network-allow-list [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for network-allow-list
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm](ybm.md)	 - ybm - Effortlessly manage your DB infrastructure on YugabyteDB Managed (DBaaS) from command line!
+* [ybm network-allow-list create](ybm_network-allow-list_create.md)	 - Create network allow lists in YugabyteDB Managed
+* [ybm network-allow-list delete](ybm_network-allow-list_delete.md)	 - Delete network allow list from YugabyteDB Managed
+* [ybm network-allow-list get](ybm_network-allow-list_get.md)	 - Get network allow list in YugabyteDB Managed
+* [ybm network-allow-list list](ybm_network-allow-list_list.md)	 - List network allow lists in YugabyteDB Managed
+

--- a/docs/ybm_network-allow-list_create.md
+++ b/docs/ybm_network-allow-list_create.md
@@ -1,0 +1,37 @@
+## ybm network-allow-list create
+
+Create network allow lists in YugabyteDB Managed
+
+### Synopsis
+
+Create network allow lists in YugabyteDB Managed
+
+```
+ybm network-allow-list create [flags]
+```
+
+### Options
+
+```
+  -i, --ip-addr strings      [REQUIRED] IP addresses included in the Network Allow List.
+  -n, --name string          [REQUIRED] The name of the Network Allow List.
+  -d, --description string   [OPTIONAL] Description of the Network Allow List.
+  -h, --help                 help for create
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm network-allow-list](ybm_network-allow-list.md)	 - Manage Network Allow Lists
+

--- a/docs/ybm_network-allow-list_delete.md
+++ b/docs/ybm_network-allow-list_delete.md
@@ -1,0 +1,35 @@
+## ybm network-allow-list delete
+
+Delete network allow list from YugabyteDB Managed
+
+### Synopsis
+
+Delete network allow list from YugabyteDB Managed
+
+```
+ybm network-allow-list delete [flags]
+```
+
+### Options
+
+```
+  -h, --help          help for delete
+  -n, --name string   [REQUIRED] The name of the Network Allow List.
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm network-allow-list](ybm_network-allow-list.md)	 - Manage Network Allow Lists
+

--- a/docs/ybm_network-allow-list_get.md
+++ b/docs/ybm_network-allow-list_get.md
@@ -1,0 +1,35 @@
+## ybm network-allow-list get
+
+Get network allow list in YugabyteDB Managed
+
+### Synopsis
+
+Get network allow list in YugabyteDB Managed
+
+```
+ybm network-allow-list get [flags]
+```
+
+### Options
+
+```
+  -h, --help          help for get
+  -n, --name string   [OPTIONAL] The name of the Network Allow List.
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm network-allow-list](ybm_network-allow-list.md)	 - Manage Network Allow Lists
+

--- a/docs/ybm_network-allow-list_list.md
+++ b/docs/ybm_network-allow-list_list.md
@@ -1,0 +1,35 @@
+## ybm network-allow-list list
+
+List network allow lists in YugabyteDB Managed
+
+### Synopsis
+
+List network allow lists in YugabyteDB Managed
+
+```
+ybm network-allow-list list [flags]
+```
+
+### Options
+
+```
+  -h, --help          help for list
+  -n, --name string   [OPTIONAL] The name of the Network Allow List.
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm network-allow-list](ybm_network-allow-list.md)	 - Manage Network Allow Lists
+

--- a/docs/ybm_region.md
+++ b/docs/ybm_region.md
@@ -1,0 +1,36 @@
+## ybm region
+
+Manage cloud regions
+
+### Synopsis
+
+Manage cloud regions for your YBM clusters
+
+```
+ybm region [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for region
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm](ybm.md)	 - ybm - Effortlessly manage your DB infrastructure on YugabyteDB Managed (DBaaS) from command line!
+* [ybm region instance](ybm_region_instance.md)	 - Manage instance types
+* [ybm region list](ybm_region_list.md)	 - List Cloud Provider Regions
+

--- a/docs/ybm_region_instance.md
+++ b/docs/ybm_region_instance.md
@@ -1,0 +1,35 @@
+## ybm region instance
+
+Manage instance types
+
+### Synopsis
+
+Manage instance types for your YBM clusters
+
+```
+ybm region instance [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for instance
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm region](ybm_region.md)	 - Manage cloud regions
+* [ybm region instance list](ybm_region_instance_list.md)	 - List the Instance Types for a region
+

--- a/docs/ybm_region_instance_list.md
+++ b/docs/ybm_region_instance_list.md
@@ -1,0 +1,38 @@
+## ybm region instance list
+
+List the Instance Types for a region
+
+### Synopsis
+
+List the Instance Types for a region
+
+```
+ybm region instance list [flags]
+```
+
+### Options
+
+```
+      --cloud-provider string   [REQUIRED] The cloud provider for which the regions have to be fetched. AWS or GCP.
+      --region string           [REQUIRED] The region in the cloud provider for which the instance types have to fetched.
+      --tier string             [OPTIONAL] Tier. Sandbox or Dedicated. (default "Dedicated")
+      --show-disabled           [OPTIONAL] Whether to show disabled instance types. true or false. (default true)
+  -h, --help                    help for list
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm region instance](ybm_region_instance.md)	 - Manage instance types
+

--- a/docs/ybm_region_list.md
+++ b/docs/ybm_region_list.md
@@ -1,0 +1,35 @@
+## ybm region list
+
+List Cloud Provider Regions
+
+### Synopsis
+
+List Cloud Provider Regions
+
+```
+ybm region list [flags]
+```
+
+### Options
+
+```
+      --cloud-provider string   [REQUIRED] The cloud provider for which the regions have to be fetched. AWS or GCP.
+  -h, --help                    help for list
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm region](ybm_region.md)	 - Manage cloud regions
+

--- a/docs/ybm_signup.md
+++ b/docs/ybm_signup.md
@@ -1,0 +1,34 @@
+## ybm signup
+
+Open a browser to sign up for YugabyteDB Managed
+
+### Synopsis
+
+Open a browser to sign up for YugabyteDB Managed
+
+```
+ybm signup [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for signup
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm](ybm.md)	 - ybm - Effortlessly manage your DB infrastructure on YugabyteDB Managed (DBaaS) from command line!
+

--- a/docs/ybm_tools.md
+++ b/docs/ybm_tools.md
@@ -1,0 +1,35 @@
+## ybm tools
+
+Tools command
+
+### Synopsis
+
+Differents tools for Yugabyte developer
+
+```
+ybm tools [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for tools
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm](ybm.md)	 - ybm - Effortlessly manage your DB infrastructure on YugabyteDB Managed (DBaaS) from command line!
+* [ybm tools gen-doc](ybm_tools_gen-doc.md)	 - Generate docs
+

--- a/docs/ybm_tools_gen-doc.md
+++ b/docs/ybm_tools_gen-doc.md
@@ -1,0 +1,35 @@
+## ybm tools gen-doc
+
+Generate docs
+
+### Synopsis
+
+Generate docs in differents format to stdin
+
+```
+ybm tools gen-doc [flags]
+```
+
+### Options
+
+```
+      --format string   [Optional] Documentation output format (markdown,yaml,rest) .(Default markdown)
+  -h, --help            help for gen-doc
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm tools](ybm_tools.md)	 - Tools command
+

--- a/docs/ybm_vpc.md
+++ b/docs/ybm_vpc.md
@@ -1,0 +1,39 @@
+## ybm vpc
+
+Manage VPCs
+
+### Synopsis
+
+Manage VPCs
+
+```
+ybm vpc [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for vpc
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm](ybm.md)	 - ybm - Effortlessly manage your DB infrastructure on YugabyteDB Managed (DBaaS) from command line!
+* [ybm vpc create](ybm_vpc_create.md)	 - Create a VPC in YugabyteDB Managed
+* [ybm vpc delete](ybm_vpc_delete.md)	 - Delete a VPC in YugabyteDB Managed
+* [ybm vpc get](ybm_vpc_get.md)	 - Get VPC in YugabyteDB Managed
+* [ybm vpc list](ybm_vpc_list.md)	 - List VPCs in YugabyteDB Managed
+* [ybm vpc peering](ybm_vpc_peering.md)	 - Manage VPC Peerings
+

--- a/docs/ybm_vpc_create.md
+++ b/docs/ybm_vpc_create.md
@@ -1,0 +1,39 @@
+## ybm vpc create
+
+Create a VPC in YugabyteDB Managed
+
+### Synopsis
+
+Create a VPC in YugabyteDB Managed
+
+```
+ybm vpc create [flags]
+```
+
+### Options
+
+```
+      --name string             [REQUIRED] Name for the VPC.
+      --cloud-provider string   [REQUIRED] Cloud provider for the VPC.
+      --global-cidr string      [OPTIONAL] Global CIDR for the VPC.
+      --region strings          [OPTIONAL] Region of the VPC.
+      --cidr strings            [OPTIONAL] CIDR of the VPC.
+  -h, --help                    help for create
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm vpc](ybm_vpc.md)	 - Manage VPCs
+

--- a/docs/ybm_vpc_delete.md
+++ b/docs/ybm_vpc_delete.md
@@ -1,0 +1,35 @@
+## ybm vpc delete
+
+Delete a VPC in YugabyteDB Managed
+
+### Synopsis
+
+Delete a VPC in YugabyteDB Managed
+
+```
+ybm vpc delete [flags]
+```
+
+### Options
+
+```
+  -h, --help          help for delete
+      --name string   [REQUIRED] Name for the VPC.
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm vpc](ybm_vpc.md)	 - Manage VPCs
+

--- a/docs/ybm_vpc_get.md
+++ b/docs/ybm_vpc_get.md
@@ -1,0 +1,35 @@
+## ybm vpc get
+
+Get VPC in YugabyteDB Managed
+
+### Synopsis
+
+Get VPC in YugabyteDB Managed
+
+```
+ybm vpc get [flags]
+```
+
+### Options
+
+```
+  -h, --help          help for get
+      --name string   [OPTIONAL] Name for the VPC.
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm vpc](ybm_vpc.md)	 - Manage VPCs
+

--- a/docs/ybm_vpc_list.md
+++ b/docs/ybm_vpc_list.md
@@ -1,0 +1,35 @@
+## ybm vpc list
+
+List VPCs in YugabyteDB Managed
+
+### Synopsis
+
+List VPCs in YugabyteDB Managed
+
+```
+ybm vpc list [flags]
+```
+
+### Options
+
+```
+  -h, --help          help for list
+      --name string   [OPTIONAL] Name for the VPC.
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm vpc](ybm_vpc.md)	 - Manage VPCs
+

--- a/docs/ybm_vpc_peering.md
+++ b/docs/ybm_vpc_peering.md
@@ -1,0 +1,38 @@
+## ybm vpc peering
+
+Manage VPC Peerings
+
+### Synopsis
+
+Manage VPC Peerings
+
+```
+ybm vpc peering [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for peering
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm vpc](ybm_vpc.md)	 - Manage VPCs
+* [ybm vpc peering create](ybm_vpc_peering_create.md)	 - Create VPC peering
+* [ybm vpc peering delete](ybm_vpc_peering_delete.md)	 - Delete VPC peering
+* [ybm vpc peering get](ybm_vpc_peering_get.md)	 - Get VPC peerings
+* [ybm vpc peering list](ybm_vpc_peering_list.md)	 - List VPC peerings
+

--- a/docs/ybm_vpc_peering_create.md
+++ b/docs/ybm_vpc_peering_create.md
@@ -1,0 +1,43 @@
+## ybm vpc peering create
+
+Create VPC peering
+
+### Synopsis
+
+Create VPC peering in YugabyteDB Managed
+
+```
+ybm vpc peering create [flags]
+```
+
+### Options
+
+```
+      --name string                 [REQUIRED] Name for the VPC peering.
+      --yb-vpc-name string          [REQUIRED] Name of the YugabyteDB Managed VPC.
+      --cloud-provider string       [REQUIRED] Cloud of the VPC with which to peer. AWS or GCP.
+      --app-vpc-name string         [OPTIONAL] Name of the application VPC. Required for GCP. Not applicable for AWS.
+      --app-vpc-project-id string   [OPTIONAL] Project ID of the application VPC. Required for GCP. Not applicable for AWS.
+      --app-vpc-cidr string         [OPTIONAL] CIDR of the application VPC. Required for AWS. Optional for GCP.
+      --app-vpc-account-id string   [OPTIONAL] Account ID of the application VPC. Required for AWS. Not applicable for GCP.
+      --app-vpc-id string           [OPTIONAL] ID of the application VPC. Required for AWS. Not applicable for GCP.
+      --app-vpc-region string       [OPTIONAL] Region of the application VPC. Required for AWS. Not applicable for GCP.
+  -h, --help                        help for create
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm vpc peering](ybm_vpc_peering.md)	 - Manage VPC Peerings
+

--- a/docs/ybm_vpc_peering_delete.md
+++ b/docs/ybm_vpc_peering_delete.md
@@ -1,0 +1,35 @@
+## ybm vpc peering delete
+
+Delete VPC peering
+
+### Synopsis
+
+Delete VPC peering in YugabyteDB Managed
+
+```
+ybm vpc peering delete [flags]
+```
+
+### Options
+
+```
+  -h, --help          help for delete
+      --name string   [REQUIRED] Name for the VPC peering.
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm vpc peering](ybm_vpc_peering.md)	 - Manage VPC Peerings
+

--- a/docs/ybm_vpc_peering_get.md
+++ b/docs/ybm_vpc_peering_get.md
@@ -1,0 +1,35 @@
+## ybm vpc peering get
+
+Get VPC peerings
+
+### Synopsis
+
+Get VPC peerings in YugabyteDB Managed
+
+```
+ybm vpc peering get [flags]
+```
+
+### Options
+
+```
+  -h, --help          help for get
+      --name string   [OPTIONAL] Name for the VPC peering.
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm vpc peering](ybm_vpc_peering.md)	 - Manage VPC Peerings
+

--- a/docs/ybm_vpc_peering_list.md
+++ b/docs/ybm_vpc_peering_list.md
@@ -1,0 +1,35 @@
+## ybm vpc peering list
+
+List VPC peerings
+
+### Synopsis
+
+List VPC peerings in YugabyteDB Managed
+
+```
+ybm vpc peering list [flags]
+```
+
+### Options
+
+```
+  -h, --help          help for list
+      --name string   [OPTIONAL] Name for the VPC peering.
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string     YBM Api Key
+      --config string     config file (default is $HOME/.ybm-cli.yaml)
+      --debug             Use debug mode, same as --logLevel debug
+  -l, --logLevel string   Select the desired log level format(info). Default to info
+      --no-color          Disable colors in output , default to false
+  -o, --output string     Select the desired output format (table, json, pretty). Default to table
+      --wait              Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm vpc peering](ybm_vpc_peering.md)	 - Manage VPC Peerings
+

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.2.0 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8 // indirect
 	github.com/cloudflare/circl v1.1.0 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
@@ -53,6 +54,7 @@ require (
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.6 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/spf13/afero v1.9.4 // indirect
 	github.com/spf13/cast v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,7 @@ github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnht
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be h1:J5BL2kskAlV9ckgEsNQXscjIaLiOYiZ75d4e94E6dcQ=
 github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be/go.mod h1:mk5IQ+Y0ZeO87b858TlA645sVcEcbiX6YqP98kt+7+w=
+github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -224,6 +225,7 @@ github.com/rivo/uniseg v0.4.4 h1:8TfxU8dW6PdqD27gjM8MVNuicgxIjxpm4K7x4jp8sis=
 github.com/rivo/uniseg v0.4.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=


### PR DESCRIPTION
This add a new command `tools gen-doc` command will create all the ybm cli command docsin the `./docs` repos.

I added a `make doc` that we should run when we update the command line.
I didn't add this in the pipeline for now.