### PR TITLE
Fix instance types API

### DIFF
--- a/cmd/region/instance_types.go
+++ b/cmd/region/instance_types.go
@@ -54,7 +54,7 @@ var getInstanceTypesCmd = &cobra.Command{
 			logrus.Fatalln(err)
 		}
 		showDisabled, _ := cmd.Flags().GetBool("show-disabled")
-		instanceTypesResp, resp, err := authApi.GetSupportedInstanceTypes(cloudProvider, tier, cloudRegion).ShowDisabled(showDisabled).Execute()
+		instanceTypesResp, resp, err := authApi.GetSupportedNodeConfigurations(cloudProvider, tier, cloudRegion).ShowDisabled(showDisabled).Execute()
 		if err != nil {
 			logrus.Debugf("Full HTTP response: %v", resp)
 			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -685,11 +685,12 @@ func (a *AuthApiClient) GetCdcStreamIDByStreamName(cdcStreamName string) (string
 	return "", fmt.Errorf("couldn't find any cdcStream with the given name")
 }
 
-func (a *AuthApiClient) GetSupportedInstanceTypes(cloud string, tier string, region string) ybmclient.ApiGetSupportedInstanceTypesRequest {
-	return a.ApiClient.ClusterApi.GetSupportedInstanceTypes(a.ctx).AccountId(a.AccountID).Cloud(cloud).Tier(tier).Region(region)
+func (a *AuthApiClient) GetSupportedNodeConfigurations(cloud string, tier string, region string) ybmclient.ApiGetSupportedNodeConfigurationsRequest {
+	return a.ApiClient.ClusterApi.GetSupportedNodeConfigurations(a.ctx).AccountId(a.AccountID).Cloud(cloud).Tier(tier).Regions([]string{region})
 }
+
 func (a *AuthApiClient) GetFromInstanceType(resource string, cloud string, tier string, region string, numCores int32) (int32, error) {
-	instanceResp, resp, err := a.GetSupportedInstanceTypes(cloud, tier, region).Execute()
+	instanceResp, resp, err := a.GetSupportedNodeConfigurations(cloud, tier, region).Execute()
 	if err != nil {
 		b, _ := httputil.DumpResponse(resp, true)
 		logrus.Debug(b)


### PR DESCRIPTION
The API that we are using for fetching instance types is almost deprecated (plans to deprecate it in the next 1-2 weeks).
Towards that, we want to move to the new API that is very similar in nature (just that it supports multi-geo).