### PR TITLE
[CLOUDGA-13718] Get project ID for CLI auth client from an API listAccounts API

### DIFF
--- a/cmd/backup_test.go
+++ b/cmd/backup_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Backup", func() {
 		statusCode      int
 		args            []string
 		responseAccount openapi.AccountListResponse
-		responseProject openapi.ProjectListResponse
+		responseProject openapi.AccountListResponse
 		responseBackup  openapi.BackupListResponse
 		//cbr        *cobra.Command
 	)

--- a/cmd/cluster_test.go
+++ b/cmd/cluster_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Cluster", func() {
 		statusCode               int
 		args                     []string
 		responseAccount          openapi.AccountListResponse
-		responseProject          openapi.ProjectListResponse
+		responseProject          openapi.AccountListResponse
 		responseListCluster      openapi.ClusterListResponse
 		responseNetworkAllowList openapi.NetworkAllowListListResponse
 		responseError            openapi.ApiError

--- a/cmd/cmd_suite_test.go
+++ b/cmd/cmd_suite_test.go
@@ -77,8 +77,9 @@ func newGhttpServer(responseAccount any, responseProject any) (*ghttp.Server, er
 			ghttp.VerifyHeaderKV("Authorization", "Bearer test-token"),
 		),
 		ghttp.CombineHandlers(
-			ghttp.VerifyRequest(http.MethodGet, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects"),
+			ghttp.VerifyRequest(http.MethodGet, "/api/public/v1/accounts"),
 			ghttp.RespondWithJSONEncodedPtr(&statusCode, responseProject),
+			ghttp.VerifyHeaderKV("Authorization", "Bearer test-token"),
 		),
 	)
 	return server, nil

--- a/cmd/test/fixtures/account.json
+++ b/cmd/test/fixtures/account.json
@@ -146,6 +146,19 @@
                             "permissions": null
                         }
                     }
+                ],
+                "projects": [
+                    {
+                        "id": "78d4459c-0f45-47a5-899a-45ddf43eba6e",
+                        "name": "default",
+                        "spec": {
+                            "name": "default"
+                        },
+                        "info": {
+                            "id": "78d4459c-0f45-47a5-899a-45ddf43eba6e"
+                        },
+                        "metadata": null
+                    }
                 ]
             },
             "spec": {

--- a/cmd/test/fixtures/projects.json
+++ b/cmd/test/fixtures/projects.json
@@ -1,24 +1,168 @@
 {
-    "_metadata": {
-        "continuation_token": null,
-        "links": {
-            "next": null,
-            "self": "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects"
-        }
-    },
+    "_metadata": {},
     "data": [
         {
-            "id": "78d4459c-0f45-47a5-899a-45ddf43eba6e",
             "info": {
-                "id": "78d4459c-0f45-47a5-899a-45ddf43eba6e"
+                "id": "340af43a-8a7c-4659-9258-4876fd6a207b",
+                "owner_id": "8bcbac89-b95e-454c-ad4d-c3167bb18462",
+                "roles": [
+                    {
+                        "account_id": "340af43a-8a7c-4659-9258-4876fd6a207b",
+                        "description": "Full access on cluster/backup - no billing or user management rights",
+                        "id": "cb6edae1-f2c7-4540-a870-521754e8a000",
+                        "info": {
+                            "id": ""
+                        },
+                        "is_active": true,
+                        "is_user_defined": false,
+                        "metadata": {
+                            "created_on": "2021-10-19T00:00Z",
+                            "updated_on": "2021-10-19T00:00Z"
+                        },
+                        "name": "account_dev",
+                        "permissions": [
+                            {
+                                "operation_groups": [
+                                    {
+                                        "operation_group": "READ",
+                                        "operation_group_description": "List or View alert rules"
+                                    },
+                                    {
+                                        "operation_group": "SEND_TEST_EMAIL",
+                                        "operation_group_description": "Send test emails for alerts"
+                                    },
+                                    {
+                                        "operation_group": "UPDATE",
+                                        "operation_group_description": "Update alert rules"
+                                    }
+                                ],
+                                "resource_name": "Alert Rules",
+                                "resource_type": "ALERT_RULE"
+                            },
+                            {
+                                "operation_groups": [
+                                    {
+                                        "operation_group": "READ",
+                                        "operation_group_description": "List Read Replicas of a cluster"
+                                    },
+                                    {
+                                        "operation_group": "UPDATE",
+                                        "operation_group_description": "Update/modify Read Replica of a cluster"
+                                    },
+                                    {
+                                        "operation_group": "DELETE",
+                                        "operation_group_description": "Delete Read Replicas"
+                                    },
+                                    {
+                                        "operation_group": "CREATE",
+                                        "operation_group_description": "Create Read Replica for a Cluster"
+                                    }
+                                ],
+                                "resource_name": "Read Replica",
+                                "resource_type": "READ_REPLICA"
+                            },
+                            {
+                                "operation_groups": [
+                                    {
+                                        "operation_group": "READ",
+                                        "operation_group_description": "List or View clusters"
+                                    }
+                                ],
+                                "resource_name": "Clusters",
+                                "resource_type": "CLUSTER"
+                            },
+                            {
+                                "operation_groups": [
+                                    {
+                                        "operation_group": "READ",
+                                        "operation_group_description": "List or view available database tracks"
+                                    }
+                                ],
+                                "resource_name": "Database Track",
+                                "resource_type": "TRACK"
+                            },
+                            {
+                                "operation_groups": [
+                                    {
+                                        "operation_group": "READ",
+                                        "operation_group_description": "List or View Maintenance Schedules"
+                                    },
+                                    {
+                                        "operation_group": "UPDATE",
+                                        "operation_group_description": "Update Maintenance Schedules"
+                                    }
+                                ],
+                                "resource_name": "Cluster Maintenance Schedule",
+                                "resource_type": "CLUSTER_MAINTENANCE_SCHEDULE"
+                            },
+                            {
+                                "operation_groups": [
+                                    {
+                                        "operation_group": "READ",
+                                        "operation_group_description": "List or View Maintenance Events of a cluster"
+                                    },
+                                    {
+                                        "operation_group": "UPDATE",
+                                        "operation_group_description": "Trigger or Delay Maintenance Events of a cluster"
+                                    }
+                                ],
+                                "resource_name": "Cluster Maintenance Event",
+                                "resource_type": "CLUSTER_MAINTENANCE_EVENT"
+                            },
+                            {
+                                "operation_groups": [
+                                    {
+                                        "operation_group": "READ",
+                                        "operation_group_description": "List or View Account related Tasks"
+                                    }
+                                ],
+                                "resource_name": "Tasks",
+                                "resource_type": "ACCOUNT_TASK"
+                            },
+                            {
+                                "operation_groups": [
+                                    {
+                                        "operation_group": "READ",
+                                        "operation_group_description": "View Information of Users associated with the account"
+                                    }
+                                ],
+                                "resource_name": "Users",
+                                "resource_type": "ACCOUNT_USER"
+                            },
+                            {
+                                "operation_groups": [
+                                    {
+                                        "operation_group": "READ",
+                                        "operation_group_description": "List or View information related to an account"
+                                    }
+                                ],
+                                "resource_name": "Account Login Type",
+                                "resource_type": "ACCOUNT_LOGIN_TYPE"
+                            }
+                        ],
+                        "spec": {
+                            "description": "",
+                            "name": "",
+                            "permissions": null
+                        }
+                    }
+                ],
+                "projects": [
+                    {
+                        "id": "78d4459c-0f45-47a5-899a-45ddf43eba6e",
+                        "name": "default",
+                        "spec": {
+                            "name": "default"
+                        },
+                        "info": {
+                            "id": "78d4459c-0f45-47a5-899a-45ddf43eba6e"
+                        },
+                        "metadata": null
+                    }
+                ]
             },
-            "metadata": {
-                "created_on": "2022-03-11T07:19:48.072Z",
-                "updated_on": "2022-03-11T07:19:48.072Z"
-            },
-            "name": "default",
             "spec": {
-                "name": "default"
+                "name": "ybcloud-473359"
             }
         }
     ]

--- a/cmd/vpc_test.go
+++ b/cmd/vpc_test.go
@@ -36,7 +36,7 @@ var _ = Describe("VPC", func() {
 		statusCode      int
 		args            []string
 		responseAccount openapi.AccountListResponse
-		responseProject openapi.ProjectListResponse
+		responseProject openapi.AccountListResponse
 		responseVPC     openapi.SingleTenantVpcListResponse
 	)
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -137,7 +137,7 @@ func (a *AuthApiClient) GetProjectID(projectID string) (string, error) {
 		return projectID, nil
 	}
 
-	projectResp, resp, err := a.ListProjects().Execute()
+	accountResp, resp, err := a.ListAccounts().Execute()
 	if err != nil {
 		errMsg := getErrorMessage(resp, err)
 		if strings.Contains(err.Error(), "is not a valid") {
@@ -148,15 +148,14 @@ func (a *AuthApiClient) GetProjectID(projectID string) (string, error) {
 			return "", fmt.Errorf(errMsg)
 		}
 	}
-	projectData := projectResp.GetData()
+	projectData := accountResp.GetData()[0].Info.GetProjects()
 	if len(projectData) == 0 {
 		return "", fmt.Errorf("the account is not associated with any projects")
 	}
 	if len(projectData) > 1 {
 		return "", fmt.Errorf("the account is associated with multiple projects, please provide a project id")
 	}
-
-	return projectData[0].Id, nil
+	return projectData[0].Info.Id, nil
 }
 
 func (a *AuthApiClient) CreateClusterSpec(cmd *cobra.Command, regionInfoList []map[string]string) (*ybmclient.ClusterSpec, error) {


### PR DESCRIPTION
listProjects() API requires the permission PROJECT.READ
Api keys with custom roles that do not have PROJECT.READ will not be able to be used with CLI (forbidden errors)
ProjectData has been added to the response of listAccounts() API (which is free from RBAC)
This PR consumes that for the CLI auth client

Test plan:
Tested locally with API keys having custom roles.

P.S. can you also help with the test failures? 