### PR TITLE
[CLOUDGA-12756] CLI changes for aws custom disk IOPS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@
 *.so
 *.dylib
 
+# Intellij files.
+.idea/
+*.iml
+
 # Test binary, built with `go test -c`
 *.test
 

--- a/cmd/cluster/create_cluster.go
+++ b/cmd/cluster/create_cluster.go
@@ -182,7 +182,7 @@ func init() {
 	cloud-provider=GCP,gcp-resource-id=<resource-id>,gcp-service-account-path=<service-account-path>.
 	If specified, all parameters for that provider are mandatory.`)
 	createClusterCmd.Flags().String("fault-tolerance", "", "[OPTIONAL] The fault tolerance of the cluster. The possible values are NONE, ZONE and REGION. Default NONE.")
-	createClusterCmd.Flags().StringToInt("node-config", nil, "[OPTIONAL] Configuration of the cluster nodes. Please provide key value pairs num-cores=<num-cores>,disk-size-gb=<disk-size-gb> as the value. If specified  num-cores is mandatory, disk-size-gb is optional.")
+	createClusterCmd.Flags().StringToInt("node-config", nil, "[OPTIONAL] Configuration of the cluster nodes. Please provide key value pairs num-cores=<num-cores>,disk-size-gb=<disk-size-gb>,disk-iops=<disk-iops> as the value. If specified, num-cores is mandatory, while disk-size-gb and disk-iops are optional.")
 	createClusterCmd.Flags().StringArray("region-info", []string{}, `[OPTIONAL] Region information for the cluster. Please provide key value pairs region=<region-name>,num-nodes=<number-of-nodes>,vpc=<vpc-name> as the value. If specified, region and num-nodes are mandatory, vpc is optional. Information about multiple regions can be specified by using multiple --region-info arguments. Default if not specified is us-west-2 AWS region.`)
 
 }

--- a/cmd/cluster/read-replica/read_replica.go
+++ b/cmd/cluster/read-replica/read_replica.go
@@ -101,7 +101,7 @@ func ParseReplicaOpts(authApi *ybmAuthClient.AuthApiClient, replicaOpts []string
 			n := 0
 			err = nil
 			switch key {
-			case "num-cores", "disk-size-gb", "num-nodes", "num-replicas":
+			case "num-cores", "disk-size-gb", "num-nodes", "num-replicas", "disk-iops":
 				n, err = strconv.Atoi(val)
 				if err != nil {
 					return nil, err
@@ -118,6 +118,11 @@ func ParseReplicaOpts(authApi *ybmAuthClient.AuthApiClient, replicaOpts []string
 				if n > 0 && n <= math.MaxInt32 {
 					/* #nosec G109 */
 					spec.NodeInfo.DiskSizeGb = int32(n)
+				}
+			case "disk-iops":
+				if n > 0 && n <= math.MaxInt32 {
+					iops := int32(n)
+					spec.NodeInfo.DiskIops.Set(&iops)
 				}
 			// Keeping code as temp. backward compatibility
 			case "code", "cloud-provider":
@@ -380,10 +385,10 @@ func init() {
 	ReadReplicaCmd.AddCommand(listReadReplicaCmd)
 
 	ReadReplicaCmd.AddCommand(createReadReplicaCmd)
-	createReadReplicaCmd.Flags().StringArrayVarP(&allReplicaOpt, "replica", "r", []string{}, `[OPTIONAL] Region information for the cluster. Please provide key value pairs num-cores=<num-cores>,disk-size-gb=<disk-size-gb>,cloud-provider=<GCP or AWS>,region=<region>,num-nodes=<num-nodes>,vpc=<vpc-name>,num-replicas=<num-replicas>,multi-zone=<multi-zone>.`)
+	createReadReplicaCmd.Flags().StringArrayVarP(&allReplicaOpt, "replica", "r", []string{}, `[OPTIONAL] Region information for the cluster. Please provide key value pairs num-cores=<num-cores>,disk-size-gb=<disk-size-gb>,disk-iops=<disk-iops>,cloud-provider=<GCP or AWS>,region=<region>,num-nodes=<num-nodes>,vpc=<vpc-name>,num-replicas=<num-replicas>,multi-zone=<multi-zone>.`)
 
 	ReadReplicaCmd.AddCommand(updateReadReplicaCmd)
-	updateReadReplicaCmd.Flags().StringArrayVarP(&allReplicaOpt, "replica", "r", []string{}, `[OPTIONAL] Region information for the cluster. Please provide key value pairs num-cores=<num-cores>,disk-size-gb=<disk-size-gb>,cloud-provider=<GCP or AWS>,region=<region>,num-nodes=<num-nodes>,vpc=<vpc-name>,num-replicas=<num-replicas>,multi-zone=<multi-zone>.`)
+	updateReadReplicaCmd.Flags().StringArrayVarP(&allReplicaOpt, "replica", "r", []string{}, `[OPTIONAL] Region information for the cluster. Please provide key value pairs num-cores=<num-cores>,disk-size-gb=<disk-size-gb>,disk-iops=<disk-iops>,cloud-provider=<GCP or AWS>,region=<region>,num-nodes=<num-nodes>,vpc=<vpc-name>,num-replicas=<num-replicas>,multi-zone=<multi-zone>.`)
 
 	ReadReplicaCmd.AddCommand(deleteReadReplicaCmd)
 	deleteReadReplicaCmd.Flags().BoolP("force", "f", false, "Bypass the prompt for non-interactive usage")

--- a/cmd/cluster/update_cluster.go
+++ b/cmd/cluster/update_cluster.go
@@ -171,7 +171,7 @@ func init() {
 	updateClusterCmd.Flags().String("new-name", "", "[OPTIONAL] The new name to be given to the cluster.")
 	updateClusterCmd.Flags().String("cloud-provider", "", "[OPTIONAL] The cloud provider where database needs to be deployed. AWS, AZURE or GCP.")
 	updateClusterCmd.Flags().String("cluster-type", "", "[OPTIONAL] Cluster replication type. SYNCHRONOUS or GEO_PARTITIONED.")
-	updateClusterCmd.Flags().StringToInt("node-config", nil, "[OPTIONAL] Configuration of the cluster nodes. Please provide key value pairs num-cores=<num-cores>,disk-size-gb=<disk-size-gb> as the value.  num-cores is mandatory, disk-size-gb is optional.")
+	updateClusterCmd.Flags().StringToInt("node-config", nil, "[OPTIONAL] Configuration of the cluster nodes. Please provide key value pairs num-cores=<num-cores>,disk-size-gb=<disk-size-gb>,disk-iops=<disk-iops> as the value. If provided, num-cores is mandatory, while disk-size-gb and disk-iops are optional.")
 	updateClusterCmd.Flags().StringArray("region-info", []string{}, `[OPTIONAL] Region information for the cluster. Please provide key value pairs, region=<region-name>,num-nodes=<number-of-nodes>,vpc=<vpc-name> as the value. If provided, region and num-nodes are mandatory, vpc is optional.`)
 	updateClusterCmd.Flags().String("cluster-tier", "", "[OPTIONAL] The tier of the cluster. Sandbox or Dedicated.")
 	updateClusterCmd.Flags().String("fault-tolerance", "", "[OPTIONAL] The fault tolerance of the cluster. The possible values are NONE, ZONE and REGION.")
@@ -209,6 +209,9 @@ func populateFlags(cmd *cobra.Command, originalSpec ybmclient.ClusterSpec, track
 		nodeConfig := ""
 		if diskSizeGb, ok := originalSpec.ClusterInfo.NodeInfo.GetDiskSizeGbOk(); ok {
 			nodeConfig += "disk-size-gb=" + strconv.Itoa(int(*diskSizeGb))
+		}
+		if diskIops, ok := originalSpec.ClusterInfo.NodeInfo.GetDiskIopsOk(); ok {
+			nodeConfig += "disk-iops=" + strconv.Itoa(int(*diskIops))
 		}
 		if numCores, ok := originalSpec.ClusterInfo.NodeInfo.GetNumCoresOk(); ok {
 			nodeConfig += ",num-cores=" + strconv.Itoa(int(*numCores))

--- a/cmd/cluster_test.go
+++ b/cmd/cluster_test.go
@@ -210,9 +210,10 @@ var _ = Describe("Cluster", func() {
 				session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).NotTo(HaveOccurred())
 				session.Wait(2)
-				Expect(session.Out).Should(gbytes.Say(
-					`Name            Tier        Version       State     Health    Regions     Nodes     Total Res.\(Vcpu/Mem/Disk\)
-stunning-sole   Dedicated   2.16.0.1-b7   ACTIVE    💚        us-west-2   1         2 / 8GB / 100GB`))
+				o := string(session.Out.Contents()[:])
+				expected := `Name            Tier        Version       State     Health    Regions     Nodes     Node Res.(Vcpu/Mem/DiskGB/IOPS)
+stunning-sole   Dedicated   2.16.0.1-b7   ACTIVE    💚        us-west-2   1         2 / 8GB / 100GB / -` + "\n"
+				Expect(o).Should(Equal(expected))
 				session.Kill()
 			})
 
@@ -242,13 +243,12 @@ stunning-sole   Dedicated   2.16.0.1-b7   ACTIVE    💚        us-west-2   1   
 				session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).NotTo(HaveOccurred())
 				session.Wait(2)
-				Expect(session.Out).Should(gbytes.Say(
-					`General
+				expected :=	`General
 Name            ID                                     Version       State     Health
 stunning-sole   5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8   2.16.0.1-b7   ACTIVE    💚
 
-Provider   Tier        Fault Tolerance   Nodes     Total Res.\(Vcpu/Mem/Disk\)
-AWS        Dedicated   NONE              1         2 / 8GB / 100GB
+Provider   Tier        Fault Tolerance   Nodes     Node Res.(Vcpu/Mem/DiskGB/IOPS)
+AWS        Dedicated   NONE              1         2 / 8GB / 100GB / -
 
 
 Regions
@@ -272,10 +272,12 @@ AWS        0a80e409-e890-42fc-b209-bafb69931b2c   arn:aws:kms:us-east-1:74584618
 
 
 Nodes
-Name            Region\[zone\]            Health    Master    Tserver   ReadReplica   Used Memory\(MB\)
-test-cli-2-n1   us-west-2\[us-west-2c\]   💚        ✅        ✅        ❌            43MB
-test-cli-2-n2   us-west-2\[us-west-2c\]   💚        ❌        ✅        ❌            27MB
-test-cli-2-n3   us-west-2\[us-west-2c\]   💚        ❌        ✅        ❌            29MB`))
+Name            Region[zone]            Health    Master    Tserver   ReadReplica   Used Memory(MB)
+test-cli-2-n1   us-west-2[us-west-2c]   💚        ✅        ✅        ❌            43MB
+test-cli-2-n2   us-west-2[us-west-2c]   💚        ❌        ✅        ❌            27MB
+test-cli-2-n3   us-west-2[us-west-2c]   💚        ❌        ✅        ❌            29MB` + "\n"
+				o := string(session.Out.Contents()[:])
+				Expect(o).Should(Equal(expected))
 				session.Kill()
 			})
 			It("should return no cluster found when cluster-name is wrong", func() {

--- a/docs/ybm_cluster_create.md
+++ b/docs/ybm_cluster_create.md
@@ -28,7 +28,7 @@ ybm cluster create [flags]
                                      	cloud-provider=GCP,gcp-resource-id=<resource-id>,gcp-service-account-path=<service-account-path>.
                                      	If specified, all parameters for that provider are mandatory.
       --fault-tolerance string       [OPTIONAL] The fault tolerance of the cluster. The possible values are NONE, ZONE and REGION. Default NONE.
-      --node-config stringToInt      [OPTIONAL] Configuration of the cluster nodes. Please provide key value pairs num-cores=<num-cores>,disk-size-gb=<disk-size-gb> as the value. If specified  num-cores is mandatory, disk-size-gb is optional. (default [])
+      --node-config stringToInt      [OPTIONAL] Configuration of the cluster nodes. Please provide key value pairs num-cores=<num-cores>,disk-size-gb=<disk-size-gb>,disk-iops=<disk-iops> as the value. If specified, num-cores is mandatory, while disk-size-gb and disk-iops are optional. (default [])
       --region-info stringArray      [OPTIONAL] Region information for the cluster. Please provide key value pairs region=<region-name>,num-nodes=<number-of-nodes>,vpc=<vpc-name> as the value. If specified, region and num-nodes are mandatory, vpc is optional. Information about multiple regions can be specified by using multiple --region-info arguments. Default if not specified is us-west-2 AWS region.
   -h, --help                         help for create
 ```

--- a/docs/ybm_cluster_read-replica_create.md
+++ b/docs/ybm_cluster_read-replica_create.md
@@ -14,7 +14,7 @@ ybm cluster read-replica create [flags]
 
 ```
   -h, --help                  help for create
-  -r, --replica stringArray   [OPTIONAL] Region information for the cluster. Please provide key value pairs num-cores=<num-cores>,disk-size-gb=<disk-size-gb>,cloud-provider=<GCP or AWS>,region=<region>,num-nodes=<num-nodes>,vpc=<vpc-name>,num-replicas=<num-replicas>,multi-zone=<multi-zone>.
+  -r, --replica stringArray   [OPTIONAL] Region information for the cluster. Please provide key value pairs num-cores=<num-cores>,disk-size-gb=<disk-size-gb>,disk-iops=<disk-iops>,cloud-provider=<GCP or AWS>,region=<region>,num-nodes=<num-nodes>,vpc=<vpc-name>,num-replicas=<num-replicas>,multi-zone=<multi-zone>.
 ```
 
 ### Options inherited from parent commands

--- a/docs/ybm_cluster_read-replica_update.md
+++ b/docs/ybm_cluster_read-replica_update.md
@@ -14,7 +14,7 @@ ybm cluster read-replica update [flags]
 
 ```
   -h, --help                  help for update
-  -r, --replica stringArray   [OPTIONAL] Region information for the cluster. Please provide key value pairs num-cores=<num-cores>,disk-size-gb=<disk-size-gb>,cloud-provider=<GCP or AWS>,region=<region>,num-nodes=<num-nodes>,vpc=<vpc-name>,num-replicas=<num-replicas>,multi-zone=<multi-zone>.
+  -r, --replica stringArray   [OPTIONAL] Region information for the cluster. Please provide key value pairs num-cores=<num-cores>,disk-size-gb=<disk-size-gb>,disk-iops=<disk-iops>,cloud-provider=<GCP or AWS>,region=<region>,num-nodes=<num-nodes>,vpc=<vpc-name>,num-replicas=<num-replicas>,multi-zone=<multi-zone>.
 ```
 
 ### Options inherited from parent commands

--- a/docs/ybm_cluster_update.md
+++ b/docs/ybm_cluster_update.md
@@ -21,7 +21,7 @@ ybm cluster update [flags]
       --fault-tolerance string    [OPTIONAL] The fault tolerance of the cluster. The possible values are NONE, ZONE and REGION.
   -h, --help                      help for update
       --new-name string           [OPTIONAL] The new name to be given to the cluster.
-      --node-config stringToInt   [OPTIONAL] Configuration of the cluster nodes. Please provide key value pairs num-cores=<num-cores>,disk-size-gb=<disk-size-gb> as the value.  num-cores is mandatory, disk-size-gb is optional. (default [])
+      --node-config stringToInt   [OPTIONAL] Configuration of the cluster nodes. Please provide key value pairs num-cores=<num-cores>,disk-size-gb=<disk-size-gb>,disk-iops=<disk-iops> as the value. If provided, num-cores is mandatory, while disk-size-gb and disk-iops are optional. (default [])
       --region-info stringArray   [OPTIONAL] Region information for the cluster. Please provide key value pairs, region=<region-name>,num-nodes=<number-of-nodes>,vpc=<vpc-name> as the value. If provided, region and num-nodes are mandatory, vpc is optional.
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -13,15 +13,15 @@ require (
 	github.com/inhies/go-bytesize v0.0.0-20220417184213-4913239db9cf
 	github.com/jayco/go-emoji-flag v0.0.0-20190810054606-01604da018da
 	github.com/mattn/go-runewidth v0.0.14
-	github.com/onsi/ginkgo/v2 v2.9.5
-	github.com/onsi/gomega v1.27.7
+	github.com/onsi/ginkgo/v2 v2.9.7
+	github.com/onsi/gomega v1.27.8
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.15.0
 	github.com/t-tomalak/logrus-easy-formatter v0.0.0-20190827215021-c074f06c5816
-	github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20230602121742-5be626bd9a29
+	github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20230612170114-34eb470a0c39
 	golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2
 	golang.org/x/mod v0.10.0
 	golang.org/x/term v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -218,10 +218,10 @@ github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RR
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
-github.com/onsi/ginkgo/v2 v2.9.5 h1:+6Hr4uxzP4XIUyAkg61dWBw8lb/gc4/X5luuxN/EC+Q=
-github.com/onsi/ginkgo/v2 v2.9.5/go.mod h1:tvAoo1QUJwNEU2ITftXTpR7R1RbCzoZUOs3RonqW57k=
-github.com/onsi/gomega v1.27.7 h1:fVih9JD6ogIiHUN6ePK7HJidyEDpWGVB5mzM7cWNXoU=
-github.com/onsi/gomega v1.27.7/go.mod h1:1p8OOlwo2iUUDsHnOrjE5UKYJ+e3W8eQ3qSlRahPmr4=
+github.com/onsi/ginkgo/v2 v2.9.7 h1:06xGQy5www2oN160RtEZoTvnP2sPhEfePYmCDc2szss=
+github.com/onsi/ginkgo/v2 v2.9.7/go.mod h1:cxrmXWykAwTwhQsJOPfdIDiJ+l2RYq7U8hFU+M/1uw0=
+github.com/onsi/gomega v1.27.8 h1:gegWiwZjBsf2DgiSbf5hpokZ98JVDMcWkUiigk6/KXc=
+github.com/onsi/gomega v1.27.8/go.mod h1:2J8vzI/s+2shY9XHRApDkdgPo1TKT7P2u6fXeJKFnNQ=
 github.com/pelletier/go-toml/v2 v2.0.6 h1:nrzqCb7j9cDFj2coyLNLaZuJTLjWjlaz6nvTvIwycIU=
 github.com/pelletier/go-toml/v2 v2.0.6/go.mod h1:eumQOmlWiOPt5WriQQqoM5y18pDHwha2N+QD+EUNTek=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=
@@ -275,8 +275,8 @@ github.com/subosito/gotenv v1.4.2 h1:X1TuBLAMDFbaTAChgCBLu3DU3UPyELpnF2jjJ2cz/S8
 github.com/subosito/gotenv v1.4.2/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
 github.com/t-tomalak/logrus-easy-formatter v0.0.0-20190827215021-c074f06c5816 h1:J6v8awz+me+xeb/cUTotKgceAYouhIB3pjzgRd6IlGk=
 github.com/t-tomalak/logrus-easy-formatter v0.0.0-20190827215021-c074f06c5816/go.mod h1:tzym/CEb5jnFI+Q0k4Qq3+LvRF4gO3E2pxS8fHP8jcA=
-github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20230602121742-5be626bd9a29 h1:tdEnRMUm5VtapK1mx5yXiHFA1z4aGuMjxG1W8B2sdyc=
-github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20230602121742-5be626bd9a29/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20230612170114-34eb470a0c39 h1:ckc1DYAEq9zNMWCMV32T0mqdposIa03zhhkYHPeDfgw=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20230612170114-34eb470a0c39/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/internal/formatter/read_replica.go
+++ b/internal/formatter/read_replica.go
@@ -18,6 +18,7 @@ package formatter
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 
 	"github.com/sirupsen/logrus"
 	ybmclient "github.com/yugabyte/yugabytedb-managed-go-client-internal"
@@ -96,18 +97,19 @@ func (c *ReadReplicaContext) Endpoint() string {
 }
 
 func (c *ReadReplicaContext) NodesSpec() string {
-	return fmt.Sprintf("%d / %s / %dGB",
-		c.totalResource(c.rrSpec.NodeInfo.NumCores),
-		convertMbtoGb(c.totalResource(c.rrSpec.NodeInfo.MemoryMb)),
-		c.totalResource(c.rrSpec.NodeInfo.DiskSizeGb))
+	iops := "-"
+	if c.rrSpec.NodeInfo.DiskIops.Get() != nil {
+		iops = strconv.Itoa(int(*c.rrSpec.NodeInfo.DiskIops.Get()))
+	}
+	return fmt.Sprintf("%d / %s / %dGB / %s",
+		c.rrSpec.NodeInfo.NumCores,
+		convertMbtoGb(c.rrSpec.NodeInfo.MemoryMb),
+		c.rrSpec.NodeInfo.DiskSizeGb,
+		iops)
 }
 
 func (c *ReadReplicaContext) Nodes() string {
 	return fmt.Sprintf("%d", c.rrSpec.PlacementInfo.NumNodes)
-}
-
-func (c *ReadReplicaContext) totalResource(resource int32) int32 {
-	return c.rrSpec.PlacementInfo.NumNodes * resource
 }
 
 func (c *ReadReplicaContext) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
Changes to create cluster, create read replica, edit cluster, edit read replica tasks to allow passing in disk iops.
Changes to list cluster, describe cluster formatting to display disk IOPS.
Changes to list cluster/rr, describe cluster -- now shows per-node resources rather than total resources.
Updated docs, fixed up broken tests.