### PR TITLE
[CLOUDGA-14116] Add sensitive permission check during user, role, api key ops

### DIFF
--- a/cmd/test/fixtures/account.json
+++ b/cmd/test/fixtures/account.json
@@ -113,16 +113,6 @@
                                 "operation_groups": [
                                     {
                                         "operation_group": "READ",
-                                        "operation_group_description": "List or View Account related Tasks"
-                                    }
-                                ],
-                                "resource_name": "Tasks",
-                                "resource_type": "ACCOUNT_TASK"
-                            },
-                            {
-                                "operation_groups": [
-                                    {
-                                        "operation_group": "READ",
                                         "operation_group_description": "View Information of Users associated with the account"
                                     }
                                 ],

--- a/cmd/test/fixtures/projects.json
+++ b/cmd/test/fixtures/projects.json
@@ -113,16 +113,6 @@
                                 "operation_groups": [
                                     {
                                         "operation_group": "READ",
-                                        "operation_group_description": "List or View Account related Tasks"
-                                    }
-                                ],
-                                "resource_name": "Tasks",
-                                "resource_type": "ACCOUNT_TASK"
-                            },
-                            {
-                                "operation_groups": [
-                                    {
-                                        "operation_group": "READ",
                                         "operation_group_description": "View Information of Users associated with the account"
                                     }
                                 ],

--- a/cmd/util/util.go
+++ b/cmd/util/util.go
@@ -29,6 +29,7 @@ import (
 )
 
 const customRoleFeatureFlagDisabled string = "Requested API not found"
+const sensitivePermissionsConfirmationMessage string = "Some of the permissions assigned to role '%s' have security implications (such as user, API key, and role management operations)."
 
 func FindNetworkAllowList(nals []ybmclient.NetworkAllowListData, name string) (ybmclient.NetworkAllowListData, error) {
 	for _, allowList := range nals {
@@ -137,4 +138,8 @@ func ConfirmCommand(message string, bypass bool) error {
 
 func GetCustomRoleFeatureFlagDisabledError() string {
 	return customRoleFeatureFlagDisabled
+}
+
+func GetSensitivePermissionsConfirmationMessage() string {
+	return sensitivePermissionsConfirmationMessage
 }

--- a/docs/ybm_api-key_create.md
+++ b/docs/ybm_api-key_create.md
@@ -18,6 +18,7 @@ ybm api-key create [flags]
       --unit string          [REQUIRED] The time units for which the API Key will be valid. Available options are Hours, Days, and Months.
       --description string   [OPTIONAL] Description of the API Key to be created.
       --role-name string     [OPTIONAL] The name of the role to be assigned to the API Key. If not provided, an Admin API Key will be generated.
+  -f, --force                Bypass the prompt for non-interactive usage
   -h, --help                 help for create
 ```
 

--- a/docs/ybm_cluster_create.md
+++ b/docs/ybm_cluster_create.md
@@ -15,7 +15,7 @@ ybm cluster create [flags]
 ```
       --cluster-name string          [REQUIRED] Name of the cluster.
       --credentials stringToString   [REQUIRED] Credentials to login to the cluster. Please provide key value pairs username=<user-name>,password=<password>. (default [])
-      --cloud-provider string        [OPTIONAL] The cloud provider where database needs to be deployed. AWS or GCP. Default AWS.
+      --cloud-provider string        [OPTIONAL] The cloud provider where database needs to be deployed. AWS, AZURE or GCP. Default AWS.
       --cluster-tier string          [OPTIONAL] The tier of the cluster. Sandbox or Dedicated. Default Sandbox.
       --cluster-type string          [OPTIONAL] Cluster replication type. SYNCHRONOUS or GEO_PARTITIONED. Default SYNCHRONOUS.
       --database-version string      [OPTIONAL] The database version of the cluster. Stable or Preview. Default depends on cluster tier, Sandbox is Preview, Dedicated is Stable.

--- a/docs/ybm_cluster_update.md
+++ b/docs/ybm_cluster_update.md
@@ -13,7 +13,7 @@ ybm cluster update [flags]
 ### Options
 
 ```
-      --cloud-provider string     [OPTIONAL] The cloud provider where database needs to be deployed. AWS or GCP.
+      --cloud-provider string     [OPTIONAL] The cloud provider where database needs to be deployed. AWS, AZURE or GCP.
       --cluster-name string       [REQUIRED] Name of the cluster.
       --cluster-tier string       [OPTIONAL] The tier of the cluster. Sandbox or Dedicated.
       --cluster-type string       [OPTIONAL] Cluster replication type. SYNCHRONOUS or GEO_PARTITIONED.

--- a/docs/ybm_region_instance_list.md
+++ b/docs/ybm_region_instance_list.md
@@ -13,7 +13,7 @@ ybm region instance list [flags]
 ### Options
 
 ```
-      --cloud-provider string   [REQUIRED] The cloud provider for which the regions have to be fetched. AWS or GCP.
+      --cloud-provider string   [REQUIRED] The cloud provider for which the regions have to be fetched. AWS, AZURE or GCP.
       --region string           [REQUIRED] The region in the cloud provider for which the instance types have to fetched.
       --tier string             [OPTIONAL] Tier. Sandbox or Dedicated. (default "Dedicated")
       --show-disabled           [OPTIONAL] Whether to show disabled instance types. true or false. (default true)

--- a/docs/ybm_region_list.md
+++ b/docs/ybm_region_list.md
@@ -13,7 +13,7 @@ ybm region list [flags]
 ### Options
 
 ```
-      --cloud-provider string   [REQUIRED] The cloud provider for which the regions have to be fetched. AWS or GCP.
+      --cloud-provider string   [REQUIRED] The cloud provider for which the regions have to be fetched. AWS, AZURE or GCP.
   -h, --help                    help for list
 ```
 

--- a/docs/ybm_role_create.md
+++ b/docs/ybm_role_create.md
@@ -16,6 +16,7 @@ ybm role create [flags]
       --role-name string          [REQUIRED] Name of the role to be created.
       --permissions stringArray   [REQUIRED] Permissions for the role. Please provide key value pairs resource-type=<resource-type>,operation-group=<operation-group> as the value. Both resource-type and operation-group are mandatory. Information about multiple permissions can be specified by using multiple --permissions arguments.
       --description string        [OPTIONAL] Description of the role to be created.
+  -f, --force                     Bypass the prompt for non-interactive usage
   -h, --help                      help for create
 ```
 

--- a/docs/ybm_user_invite.md
+++ b/docs/ybm_user_invite.md
@@ -14,6 +14,7 @@ ybm user invite [flags]
 
 ```
       --email string       [REQUIRED] The email of the user to be invited.
+  -f, --force              Bypass the prompt for non-interactive usage
   -h, --help               help for invite
       --role-name string   [REQUIRED] The name of the role to be assigned to the user.
 ```

--- a/docs/ybm_vpc_create.md
+++ b/docs/ybm_vpc_create.md
@@ -14,7 +14,7 @@ ybm vpc create [flags]
 
 ```
       --name string             [REQUIRED] Name for the VPC.
-      --cloud-provider string   [REQUIRED] Cloud provider for the VPC.
+      --cloud-provider string   [REQUIRED] Cloud provider for the VPC: AWS, AZURE or GCP.
       --global-cidr string      [OPTIONAL] Global CIDR for the VPC.
       --region strings          [OPTIONAL] Region of the VPC.
       --cidr strings            [OPTIONAL] CIDR of the VPC.

--- a/go.sum
+++ b/go.sum
@@ -276,8 +276,6 @@ github.com/subosito/gotenv v1.4.2 h1:X1TuBLAMDFbaTAChgCBLu3DU3UPyELpnF2jjJ2cz/S8
 github.com/subosito/gotenv v1.4.2/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
 github.com/t-tomalak/logrus-easy-formatter v0.0.0-20190827215021-c074f06c5816 h1:J6v8awz+me+xeb/cUTotKgceAYouhIB3pjzgRd6IlGk=
 github.com/t-tomalak/logrus-easy-formatter v0.0.0-20190827215021-c074f06c5816/go.mod h1:tzym/CEb5jnFI+Q0k4Qq3+LvRF4gO3E2pxS8fHP8jcA=
-github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20230612170114-34eb470a0c39 h1:ckc1DYAEq9zNMWCMV32T0mqdposIa03zhhkYHPeDfgw=
-github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20230612170114-34eb470a0c39/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
 github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20230616084337-3e2516a65d09 h1:B5fnbQTEbM0QX8R77NYCiGVlEzOq66V+lN2OYb+THTI=
 github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20230616084337-3e2516a65d09/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
There are some permissions tagged as "SENSITIVE" (eg. API_KEY.CREATE, ROLE.CREATE etc)
We need to check for these permissions in the following cases:
1. {create role, update role} commands- if any of the input permissions are sensitive permissions, we have to require confirmation
2. {invite user, update user, create API Key}  commands- if any of the roles provided for these operations contain sensitive permissions, we have to require confirmation 