### PR TITLE
Multiple tags for same commit

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,25 +1,38 @@
 project_name: ybm
 builds:
-- env:
-  - CGO_ENABLED=0
-  mod_timestamp: '{{ .CommitTimestamp }}'
-  flags:
-  - -trimpath
-  ldflags:
-  - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
-  goos:
-  - windows
-  - linux
-  - darwin
-  goarch:
-  - amd64
-  - arm64
-  binary: '{{ .ProjectName }}'
+  - env:
+      - CGO_ENABLED=0
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    flags:
+      - -trimpath
+    ldflags:
+      - "-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}"
+    goos:
+      - windows
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    binary: "{{ .ProjectName }}"
+
+# In case there are multiple tags for the same commit, pick the latest one.
+git:
+  tag_sort: -v:creatordate
+
+# Generate a changelog
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+
 archives:
-- format: zip
-  name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+  - format: zip
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 checksum:
-  name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
+  name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"
   algorithm: sha256
 release:
   # If set to auto, will mark the release as not ready for production


### PR DESCRIPTION
When we have multiple tags for the same commit (`v0.1.1-rc1` and `v0.1.1`), goreleaser runs into issues because it always picks the tags in alphanumeric order (so it picks `v0.1.1-rc1` for both releases). GitHub complains that the package already exists, so it refuses to upload.

Also, add a Changelog for releases.