### PR TITLE
Remove calling api from error

### DIFF
--- a/cmd/cdc/cdc_sink.go
+++ b/cmd/cdc/cdc_sink.go
@@ -67,7 +67,7 @@ var listCdcSinkCmd = &cobra.Command{
 		resp, r, err := cdcSinkRequest.Execute()
 		if err != nil {
 			logrus.Debugf("Full HTTP response: %v", r)
-			logrus.Fatalf("Error when calling `CdcApi.GetCdcSink`: %s", ybmAuthClient.GetApiErrorDetails(err))
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 
 		printCdcSinkOutput(resp.GetData())
@@ -119,7 +119,7 @@ var createCdcSinkCmd = &cobra.Command{
 		resp, r, err := authApi.CreateCdcSink().CreateCdcSinkRequest(*createSinkRequest).Execute()
 		if err != nil {
 			logrus.Debugf("Full HTTP response: %v", r)
-			logrus.Fatalf("Error when calling `CdcApi.CreateCdcSink`: %s", ybmAuthClient.GetApiErrorDetails(err))
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 
 		printCdcSinkOutput([]ybmclient.CdcSinkData{resp.GetData()})
@@ -172,7 +172,7 @@ var editCdcSinkCmd = &cobra.Command{
 		resp, r, err := authApi.EditCdcSink(cdcSinkID).EditCdcSinkRequest(*editCdcSinkRequest).Execute()
 		if err != nil {
 			logrus.Debugf("Full HTTP response: %v", r)
-			logrus.Fatalf("Error when calling `CdcApi.EditCdcSink`: %s", ybmAuthClient.GetApiErrorDetails(err))
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 
 		printCdcSinkOutput([]ybmclient.CdcSinkData{resp.GetData()})
@@ -200,7 +200,7 @@ var deleteCdcSinkCmd = &cobra.Command{
 		resp, err := authApi.DeleteCdcSink(cdcSinkID).Execute()
 		if err != nil {
 			logrus.Debugf("Full HTTP response: %v", resp)
-			logrus.Fatalf("Error when calling `CdcApi.DeleteCdcSink`: %s", ybmAuthClient.GetApiErrorDetails(err))
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 
 		fmt.Fprintf(os.Stdout, "CDC sink deleted successfully")

--- a/cmd/cdc/cdc_stream.go
+++ b/cmd/cdc/cdc_stream.go
@@ -72,7 +72,7 @@ var listCdcStreamCmd = &cobra.Command{
 		resp, r, err := cdcStreamRequest.Execute()
 		if err != nil {
 			logrus.Debugf("Full HTTP response: %v", r)
-			logrus.Fatalf("Error when calling `CdcApi.GetCdcStream`: %s", ybmAuthClient.GetApiErrorDetails(err))
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 		printCdcStreamOutput(resp.GetData())
 	},
@@ -120,7 +120,7 @@ var createCdcStreamCmd = &cobra.Command{
 		resp, r, err := authApi.CreateCdcStream(clusterID).CdcStreamSpec(cdcStreamSpec).Execute()
 		if err != nil {
 			logrus.Debugf("Full HTTP response: %v", r)
-			logrus.Fatalf("Error when calling `CdcApi.CreateCdcStream`: %s", ybmAuthClient.GetApiErrorDetails(err))
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 
 		msg := fmt.Sprintf("The CDC stream %s is being created", formatter.Colorize(cdcStreamName, formatter.GREEN_COLOR))
@@ -178,7 +178,7 @@ var editCdcStreamCmd = &cobra.Command{
 		resp, r, err := authApi.EditCdcStream(cdcStreamID, clusterID).EditCdcStreamRequest(*editCdcStreamRequest).Execute()
 		if err != nil {
 			logrus.Debugf("Full HTTP response: %v", r)
-			logrus.Fatalf("Error when calling `CdcApi.EditCdcStream`: %s", ybmAuthClient.GetApiErrorDetails(err))
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 
 		msg := fmt.Sprintf("The CDC stream %s is being updated", formatter.Colorize(cdcStreamName, formatter.GREEN_COLOR))
@@ -232,7 +232,7 @@ var deleteCdcStreamCmd = &cobra.Command{
 		resp, err := authApi.DeleteCdcStream(cdcStreamID, clusterID).Execute()
 		if err != nil {
 			logrus.Debugf("Full HTTP response: %v", resp)
-			logrus.Fatalf("Error when calling `CdcApi.DeleteCdcStream`: %s", ybmAuthClient.GetApiErrorDetails(err))
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 
 		msg := fmt.Sprintf("The CDC stream %s is being deleted", formatter.Colorize(cdcStreamName, formatter.GREEN_COLOR))

--- a/cmd/cluster/network/endpoint/delete_endpoint.go
+++ b/cmd/cluster/network/endpoint/delete_endpoint.go
@@ -51,7 +51,7 @@ var deleteEndpointCmd = &cobra.Command{
 		endpointId, _ := cmd.Flags().GetString("endpoint-id")
 		clusterEndpoint, clusterId, err := authApi.GetEndpointByIdForClusterByName(clusterName, endpointId)
 		if err != nil {
-			logrus.Fatalf("Error when calling `ClusterApi.GetEndpointByIdForClusterByName`: %s\n", ybmAuthClient.GetApiErrorDetails(err))
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 
 		// We currently support fetching just Private Service Endpoints
@@ -62,7 +62,7 @@ var deleteEndpointCmd = &cobra.Command{
 			r, err := authApi.DeletePrivateServiceEndpoint(clusterId, endpointId).Execute()
 			if err != nil {
 				logrus.Debugf("Full HTTP response: %v", r)
-				logrus.Fatalf("Error when calling `ClusterApi.DeletePrivateServiceEndpoint`: %s\n", ybmAuthClient.GetApiErrorDetails(err))
+				logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 			}
 
 			msg := fmt.Sprintf("Deleted endpoint %s", endpointId)

--- a/cmd/cluster/network/endpoint/describe_endpoint.go
+++ b/cmd/cluster/network/endpoint/describe_endpoint.go
@@ -41,7 +41,7 @@ var describeEndpointCmd = &cobra.Command{
 		endpointId, _ := cmd.Flags().GetString("endpoint-id")
 		clusterEndpoint, clusterId, err := authApi.GetEndpointByIdForClusterByName(clusterName, endpointId)
 		if err != nil {
-			logrus.Fatalf("Error when calling `ClusterApi.GetEndpointByIdForClusterByName`: %s\n", ybmAuthClient.GetApiErrorDetails(err))
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 
 		// We currently support fetching just Private Service Endpoints
@@ -52,7 +52,7 @@ var describeEndpointCmd = &cobra.Command{
 			pseGetResponse, r, err := authApi.GetPrivateServiceEndpoint(clusterId, endpointId).Execute()
 			if err != nil {
 				logrus.Debugf("Full HTTP response: %v", r)
-				logrus.Fatalf("Error when calling `ClusterApi.GetPrivateServiceEndpoint`: %s\n", ybmAuthClient.GetApiErrorDetails(err))
+				logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 			}
 			if viper.GetString("output") == "table" {
 				psEndpointContext := *formatter.NewPSEndpointContext()

--- a/cmd/cluster/network/endpoint/update_endpoint.go
+++ b/cmd/cluster/network/endpoint/update_endpoint.go
@@ -40,7 +40,7 @@ var updateEndpointCmd = &cobra.Command{
 		endpointId, _ := cmd.Flags().GetString("endpoint-id")
 		clusterEndpoint, clusterId, err := authApi.GetEndpointByIdForClusterByName(clusterName, endpointId)
 		if err != nil {
-			logrus.Fatalf("Error when calling `ClusterApi.GetEndpointByIdForClusterByName`: %s\n", ybmAuthClient.GetApiErrorDetails(err))
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 
 		// We currently support fetching just Private Service Endpoints
@@ -54,7 +54,7 @@ var updateEndpointCmd = &cobra.Command{
 			pseGetResponse, r, err := authApi.GetPrivateServiceEndpoint(clusterId, endpointId).Execute()
 			if err != nil {
 				logrus.Debugf("Full HTTP response: %v", r)
-				logrus.Fatalf("Error when calling `ClusterApi.GetPrivateServiceEndpoint`: %s\n", ybmAuthClient.GetApiErrorDetails(err))
+				logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 			}
 
 			securityPrincipalsString, _ := cmd.Flags().GetString("security-principals")
@@ -70,7 +70,7 @@ var updateEndpointCmd = &cobra.Command{
 			updateResp, r, err := authApi.EditPrivateServiceEndpoint(clusterId, endpointId).PrivateServiceEndpointRegionSpec(pseSpec[0]).Execute()
 			if err != nil {
 				logrus.Debugf("Full HTTP response: %v", r)
-				logrus.Fatalf("Error when calling `ClusterApi.EditPrivateServiceEndpoint`: %s\n", ybmAuthClient.GetApiErrorDetails(err))
+				logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 			}
 
 			msg := fmt.Sprintf("Updated endpoint %s", updateResp.Data.Info.Id)

--- a/cmd/cluster/read-replica/read_replica.go
+++ b/cmd/cluster/read-replica/read_replica.go
@@ -201,7 +201,7 @@ var listReadReplicaCmd = &cobra.Command{
 		resp, r, err := authApi.ListReadReplicas(clusterID).Execute()
 		if err != nil {
 			logrus.Debugf("Full HTTP response: %v", r)
-			logrus.Fatalf("Error when calling `ReadReplicaApi.ListReadReplicas`: %s", ybmAuthClient.GetApiErrorDetails(err))
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 
 		printReadReplicaOutput(resp)
@@ -246,7 +246,7 @@ var createReadReplicaCmd = &cobra.Command{
 		resp, r, err := authApi.CreateReadReplica(clusterID).ReadReplicaSpec(readReplicaSpecs).Execute()
 		if err != nil {
 			logrus.Debugf("Full HTTP response: %v", r)
-			logrus.Fatalf("Error when calling `ReadReplicaApi.CreateReadReplica`: %s", ybmAuthClient.GetApiErrorDetails(err))
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 
 		msg := fmt.Sprintf("Read Replica is being created for cluster %s", formatter.Colorize(ClusterName, formatter.GREEN_COLOR))
@@ -264,7 +264,7 @@ var createReadReplicaCmd = &cobra.Command{
 			resp, r, err = authApi.ListReadReplicas(clusterID).Execute()
 			if err != nil {
 				logrus.Debugf("Full HTTP response: %v", r)
-				logrus.Fatalf("Error when calling `ReadReplicaApi.ListReadReplicas`: %s", ybmAuthClient.GetApiErrorDetails(err))
+				logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 			}
 		} else {
 			fmt.Println(msg)
@@ -310,7 +310,7 @@ var updateReadReplicaCmd = &cobra.Command{
 		resp, r, err := authApi.EditReadReplicas(clusterID).ReadReplicaSpec(readReplicaSpecs).Execute()
 		if err != nil {
 			logrus.Debugf("Full HTTP response: %v", r)
-			logrus.Fatalf("Error when calling `ReadReplicaApi.EditReadReplicas`: %s", ybmAuthClient.GetApiErrorDetails(err))
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 		msg := fmt.Sprintf("Read Replica is being updated for cluster %s", formatter.Colorize(ClusterName, formatter.GREEN_COLOR))
 
@@ -327,7 +327,7 @@ var updateReadReplicaCmd = &cobra.Command{
 			resp, r, err = authApi.ListReadReplicas(clusterID).Execute()
 			if err != nil {
 				logrus.Debugf("Full HTTP response: %v", r)
-				logrus.Fatalf("Error when calling `ReadReplicaApi.ListReadReplicas`: %s", ybmAuthClient.GetApiErrorDetails(err))
+				logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 			}
 		} else {
 			fmt.Println(msg)
@@ -361,7 +361,7 @@ var deleteReadReplicaCmd = &cobra.Command{
 		r, err := authApi.DeleteReadReplica(clusterID).Execute()
 		if err != nil {
 			logrus.Debugf("Full HTTP response: %v", r)
-			logrus.Fatalf("Error when calling `ReadReplicaApi.DeleteReadReplica`: %s", ybmAuthClient.GetApiErrorDetails(err))
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 		msg := fmt.Sprintf("Read Replica is being deleted for cluster %s", formatter.Colorize(ClusterName, formatter.GREEN_COLOR))
 

--- a/cmd/nal/network_allow_list.go
+++ b/cmd/nal/network_allow_list.go
@@ -57,7 +57,7 @@ var listNetworkAllowListCmd = &cobra.Command{
 		resp, r, err := authApi.ListNetworkAllowLists().Execute()
 		if err != nil {
 			logrus.Debugf("Full HTTP response: %v", r)
-			logrus.Fatalf("Error when calling `NetworkApi.ListNetworkAllowLists`: %s", ybmAuthClient.GetApiErrorDetails(err))
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 
 		respFilter = resp.GetData()
@@ -101,7 +101,7 @@ var createNetworkAllowListCmd = &cobra.Command{
 		resp, r, err := authApi.CreateNetworkAllowList().NetworkAllowListSpec(nalSpec).Execute()
 		if err != nil {
 			logrus.Debugf("Full HTTP response: %v", r)
-			logrus.Fatalf("Error when calling `NetworkApi.ListNetworkAllowLists`: %s", ybmAuthClient.GetApiErrorDetails(err))
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 
 		nalCtx := formatter.Context{
@@ -137,7 +137,7 @@ var deleteNetworkAllowListCmd = &cobra.Command{
 		resp, r, err := authApi.ListNetworkAllowLists().Execute()
 		if err != nil {
 			logrus.Debugf("Full HTTP response: %v", r)
-			logrus.Fatalf("Error when calling `NetworkApi.ListNetworkAllowLists`: %s", ybmAuthClient.GetApiErrorDetails(err))
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 
 		allowList, err := util.FindNetworkAllowList(resp.Data, nalName)
@@ -149,7 +149,7 @@ var deleteNetworkAllowListCmd = &cobra.Command{
 		r, err = authApi.DeleteNetworkAllowList(allowList.Info.Id).Execute()
 		if err != nil {
 			logrus.Debugf("Full HTTP response: %v", r)
-			logrus.Fatalf("Error when calling `NetworkApi.DeleteNetworkAllowList`: %s", ybmAuthClient.GetApiErrorDetails(err))
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 		fmt.Printf("NetworkAllowList %s successfully deleted\n", formatter.Colorize(nalName, formatter.GREEN_COLOR))
 	},

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -845,7 +845,7 @@ func (a *AuthApiClient) GetRoleIdByName(roleName string) (string, error) {
 		return roleData.Info.GetId(), nil
 	}
 
-	return "", fmt.Errorf("Could not get role data for role name: %s", roleName)
+	return "", fmt.Errorf("could not get role data for role name: %s", roleName)
 }
 
 func (a *AuthApiClient) GetRoleByName(roleName string) (ybmclient.RoleData, error) {
@@ -874,7 +874,7 @@ func (a *AuthApiClient) GetRoleByName(roleName string) (ybmclient.RoleData, erro
 		return roleData[0], nil
 	}
 
-	return ybmclient.RoleData{}, fmt.Errorf("Could not get role data for role name: %s", roleName)
+	return ybmclient.RoleData{}, fmt.Errorf("could not get role data for role name: %s", roleName)
 }
 
 func (a *AuthApiClient) ListResourcePermissions() ybmclient.ApiListResourcePermissionsRequest {
@@ -980,7 +980,7 @@ func (a *AuthApiClient) GetKeyIdByName(name string) (string, error) {
 		return apiKeyData.Info.GetId(), nil
 	}
 
-	return "", fmt.Errorf("Could not get API key data for name: %s", name)
+	return "", fmt.Errorf("could not get API key data for name: %s", name)
 }
 
 func (a *AuthApiClient) GetApiKeyByName(name string) (ybmclient.ApiKeyData, error) {
@@ -997,7 +997,7 @@ func (a *AuthApiClient) GetApiKeyByName(name string) (ybmclient.ApiKeyData, erro
 		return keyData[0], nil
 	}
 
-	return ybmclient.ApiKeyData{}, fmt.Errorf("Could not get API Key data for name: %s", name)
+	return ybmclient.ApiKeyData{}, fmt.Errorf("could not get API Key data for name: %s", name)
 }
 
 func (a *AuthApiClient) ListAccountUsers() ybmclient.ApiListAccountUsersRequest {
@@ -1037,7 +1037,7 @@ func (a *AuthApiClient) GetUserIdByEmail(email string) (string, error) {
 		return userData.Info.GetId(), nil
 	}
 
-	return "", fmt.Errorf("Could not get user data for email: %s", email)
+	return "", fmt.Errorf("could not get user data for email: %s", email)
 }
 
 func (a *AuthApiClient) GetUserByEmail(email string) (ybmclient.UserData, error) {
@@ -1054,7 +1054,7 @@ func (a *AuthApiClient) GetUserByEmail(email string) (ybmclient.UserData, error)
 		return userData[0], nil
 	}
 
-	return ybmclient.UserData{}, fmt.Errorf("Could not get user data for email: %s", email)
+	return ybmclient.UserData{}, fmt.Errorf("could not get user data for email: %s", email)
 }
 
 func (a *AuthApiClient) WaitForTaskCompletion(entityId string, entityType ybmclient.EntityTypeEnum, taskType ybmclient.TaskTypeEnum, completionStatus []string, message string) (string, error) {
@@ -1090,7 +1090,7 @@ func (a *AuthApiClient) WaitForTaskCompletionCI(entityId string, entityType ybmc
 			taskList, resp, err = apiRequest.Execute()
 			if err != nil {
 				logrus.Debugf("Full HTTP response: %v", resp)
-				return "", fmt.Errorf("error when calling `TaskApi.ListTasks`: %s", GetApiErrorDetails(err))
+				return "", fmt.Errorf(GetApiErrorDetails(err))
 			}
 
 			if v, ok := taskList.GetDataOk(); ok && v != nil {
@@ -1154,7 +1154,7 @@ func (a *AuthApiClient) WaitForTaskCompletionFull(entityId string, entityType yb
 			taskList, resp, err = apiRequest.Execute()
 			if err != nil {
 				logrus.Debugf("Full HTTP response: %v", resp)
-				return "", fmt.Errorf("error when calling `TaskApi.ListTasks`: %s", GetApiErrorDetails(err))
+				return "", fmt.Errorf(GetApiErrorDetails(err))
 			}
 
 			if v, ok := taskList.GetDataOk(); ok && v != nil {


### PR DESCRIPTION
Remove unecessary information, just return what the api told us.
At the same time fix some static check, "error strings should not be capitalized" see https://staticcheck.io/docs/checks#ST1005