### PR TITLE
Use non deprecated description field from roles response

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.15.0
 	github.com/t-tomalak/logrus-easy-formatter v0.0.0-20190827215021-c074f06c5816
-	github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20230616084337-3e2516a65d09
+	github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20230702053718-8482a409794f
 	golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2
 	golang.org/x/mod v0.10.0
 	golang.org/x/term v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -276,8 +276,8 @@ github.com/subosito/gotenv v1.4.2 h1:X1TuBLAMDFbaTAChgCBLu3DU3UPyELpnF2jjJ2cz/S8
 github.com/subosito/gotenv v1.4.2/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
 github.com/t-tomalak/logrus-easy-formatter v0.0.0-20190827215021-c074f06c5816 h1:J6v8awz+me+xeb/cUTotKgceAYouhIB3pjzgRd6IlGk=
 github.com/t-tomalak/logrus-easy-formatter v0.0.0-20190827215021-c074f06c5816/go.mod h1:tzym/CEb5jnFI+Q0k4Qq3+LvRF4gO3E2pxS8fHP8jcA=
-github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20230616084337-3e2516a65d09 h1:B5fnbQTEbM0QX8R77NYCiGVlEzOq66V+lN2OYb+THTI=
-github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20230616084337-3e2516a65d09/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20230702053718-8482a409794f h1:pQ2GnaqG+bfNR1NMWLw2D8RbRqDX9AyMTBaINVUqCrU=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20230702053718-8482a409794f/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/internal/formatter/roles.go
+++ b/internal/formatter/roles.go
@@ -84,7 +84,7 @@ func (r *RoleContext) Name() string {
 }
 
 func (r *RoleContext) Description() string {
-	return r.r.GetDescription()
+	return r.r.Spec.GetDescription()
 }
 
 func (r *RoleContext) RoleType() string {


### PR DESCRIPTION
Some fields are going to be removed from RoleData. Removing usages of such fields. (high level fields will be removed. All the information will now only be under "spec" and "info")