### PR TITLE
[CLOUDGA-14133] Add support for enterprise-security cluster setting

### DIFF
--- a/cmd/cluster/create_cluster.go
+++ b/cmd/cluster/create_cluster.go
@@ -173,6 +173,7 @@ func init() {
 	createClusterCmd.Flags().String("cluster-tier", "", "[OPTIONAL] The tier of the cluster. Sandbox or Dedicated. Default Sandbox.")
 	createClusterCmd.Flags().String("cluster-type", "", "[OPTIONAL] Cluster replication type. SYNCHRONOUS or GEO_PARTITIONED. Default SYNCHRONOUS.")
 	createClusterCmd.Flags().String("database-version", "", "[OPTIONAL] The database version of the cluster. Stable or Preview. Default depends on cluster tier, Sandbox is Preview, Dedicated is Stable.")
+	createClusterCmd.Flags().Bool("enterprise-security", false, "[OPTIONAL] The security level of cluster. Advanced security will have security checks for cluster. Default false.")
 	createClusterCmd.Flags().String("encryption-spec", "", `[OPTIONAL] The customer managed key spec for the cluster.
 	Please provide key value pairs as follows:
 	For AWS: 

--- a/cmd/util/feature_flags.go
+++ b/cmd/util/feature_flags.go
@@ -25,12 +25,13 @@ import (
 type FeatureFlag string
 
 const (
-	CDC                FeatureFlag = "CDC"
-	CONFIGURE_URL      FeatureFlag = "CONFIGURE_URL"
-	NODE_OP            FeatureFlag = "NODE_OPS"
-	TOOLS              FeatureFlag = "TOOLS"
-	AZURE_CIDR_ALLOWED FeatureFlag = "AZURE_CIDR_ALLOWED"
-	CLUSTER_CMK_UPDATE FeatureFlag = "CLUSTER_CMK_UPDATE"
+	CDC                 FeatureFlag = "CDC"
+	CONFIGURE_URL       FeatureFlag = "CONFIGURE_URL"
+	NODE_OP             FeatureFlag = "NODE_OPS"
+	TOOLS               FeatureFlag = "TOOLS"
+	AZURE_CIDR_ALLOWED  FeatureFlag = "AZURE_CIDR_ALLOWED"
+	CLUSTER_CMK_UPDATE  FeatureFlag = "CLUSTER_CMK_UPDATE"
+	ENTERPRISE_SECURITY FeatureFlag = "ENTERPRISE_SECURITY"
 )
 
 func (f FeatureFlag) String() string {

--- a/docs/ybm_cluster_create.md
+++ b/docs/ybm_cluster_create.md
@@ -19,6 +19,7 @@ ybm cluster create [flags]
       --cluster-tier string          [OPTIONAL] The tier of the cluster. Sandbox or Dedicated. Default Sandbox.
       --cluster-type string          [OPTIONAL] Cluster replication type. SYNCHRONOUS or GEO_PARTITIONED. Default SYNCHRONOUS.
       --database-version string      [OPTIONAL] The database version of the cluster. Stable or Preview. Default depends on cluster tier, Sandbox is Preview, Dedicated is Stable.
+      --enterprise-security          [OPTIONAL] The security level of cluster. Advanced security will have security checks for cluster.
       --encryption-spec string       [OPTIONAL] The customer managed key spec for the cluster.
                                      	Please provide key value pairs as follows:
                                      	For AWS: 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -253,6 +253,10 @@ func (a *AuthApiClient) CreateClusterSpec(cmd *cobra.Command, regionInfoList []m
 		faultTolerance, _ := cmd.Flags().GetString("fault-tolerance")
 		clusterInfo.SetFaultTolerance(ybmclient.ClusterFaultTolerance(faultTolerance))
 	}
+	if util.IsFeatureFlagEnabled(util.ENTERPRISE_SECURITY) && cmd.Flags().Changed("enterprise-security") {
+		enterpriseSecurity, _ := cmd.Flags().GetBool("enterprise-security")
+		clusterInfo.SetEnterpriseSecurity(enterpriseSecurity)
+	}
 	clusterInfo.SetIsProduction(isProduction)
 	clusterInfo.SetNodeInfo(*ybmclient.NewClusterNodeInfoWithDefaults())
 


### PR DESCRIPTION
Summary:
Adding support for `enterprise-security` flag which is part of createClusterRequest (CreateClusterRequest --> ClusterSpec --> ClusterInfo --> enterprise_security) for scrum: enabling PCI-DSS in YBM.

Test Plan:
created a cluster using the below command:
`./ybm cluster create     --cluster-name=test-cluster1 --enterprise-security     --credentials=username=admin,password=YBM.Is.Always.Great!`