### PR TITLE
[CLOUDGA-15694] Add support fror RF5/RF7 clusters

### DIFF
--- a/cmd/cluster/create_cluster.go
+++ b/cmd/cluster/create_cluster.go
@@ -186,7 +186,10 @@ func init() {
 	For GCP:
 	cloud-provider=GCP,gcp-resource-id=<resource-id>,gcp-service-account-path=<service-account-path>.
 	If specified, all parameters for that provider are mandatory.`)
-	createClusterCmd.Flags().String("fault-tolerance", "", "[OPTIONAL] The fault tolerance of the cluster. The possible values are NONE, ZONE and REGION. Default NONE.")
+	createClusterCmd.Flags().String("fault-tolerance", "", "[OPTIONAL] The fault tolerance domain of the cluster. The possible values are NONE, ZONE and REGION. Default NONE.")
+	if util.IsFeatureFlagEnabled(util.CLUSTER_RF) {
+		createClusterCmd.Flags().Int32("num-faults-to-tolerate", 0, "[OPTIONAL] The number of domain faults to tolerate for the level specified. The possible values are 0 for NONE, 1 for ZONE and [1-3] for anything else. Defaults to 0 for NONE, 1 otherwise.")
+	}
 	createClusterCmd.Flags().StringToInt("node-config", nil, "[OPTIONAL] Configuration of the cluster nodes. Please provide key value pairs num-cores=<num-cores>,disk-size-gb=<disk-size-gb>,disk-iops=<disk-iops> as the value. If specified, num-cores is mandatory, while disk-size-gb and disk-iops are optional.")
 	createClusterCmd.Flags().StringArray("region-info", []string{}, `[OPTIONAL] Region information for the cluster. Please provide key value pairs region=<region-name>,num-nodes=<number-of-nodes>,vpc=<vpc-name> as the value. If specified, region and num-nodes are mandatory, vpc is optional. Information about multiple regions can be specified by using multiple --region-info arguments. Default if not specified is us-west-2 AWS region.`)
 

--- a/cmd/cluster/update_cluster.go
+++ b/cmd/cluster/update_cluster.go
@@ -174,7 +174,7 @@ func init() {
 	updateClusterCmd.Flags().StringToInt("node-config", nil, "[OPTIONAL] Configuration of the cluster nodes. Please provide key value pairs num-cores=<num-cores>,disk-size-gb=<disk-size-gb>,disk-iops=<disk-iops> as the value. If provided, num-cores is mandatory, while disk-size-gb and disk-iops are optional.")
 	updateClusterCmd.Flags().StringArray("region-info", []string{}, `[OPTIONAL] Region information for the cluster. Please provide key value pairs, region=<region-name>,num-nodes=<number-of-nodes>,vpc=<vpc-name> as the value. If provided, region and num-nodes are mandatory, vpc is optional.`)
 	updateClusterCmd.Flags().String("cluster-tier", "", "[OPTIONAL] The tier of the cluster. Sandbox or Dedicated.")
-	updateClusterCmd.Flags().String("fault-tolerance", "", "[OPTIONAL] The fault tolerance of the cluster. The possible values are NONE, ZONE and REGION.")
+	updateClusterCmd.Flags().String("fault-tolerance", "", "[OPTIONAL] The fault tolerance domain of the cluster. The possible values are NONE, ZONE and REGION.")
 	updateClusterCmd.Flags().String("database-version", "", "[OPTIONAL] The database version of the cluster. Production or Innovation or Preview.")
 
 }

--- a/cmd/test/fixtures/list-clusters.json
+++ b/cmd/test/fixtures/list-clusters.json
@@ -12,6 +12,7 @@
                     "cluster_type": "SYNCHRONOUS",
                     "num_nodes": 1,
                     "fault_tolerance": "NONE",
+                    "num_faults_to_tolerate": 0,
                     "node_info": {
                         "num_cores": 2,
                         "memory_mb": 8192,

--- a/cmd/test/fixtures/one-cluster.json
+++ b/cmd/test/fixtures/one-cluster.json
@@ -12,6 +12,7 @@
                     "cluster_type": "SYNCHRONOUS",
                     "num_nodes": 1,
                     "fault_tolerance": "NONE",
+                    "num_faults_to_tolerate": 0,
                     "node_info": {
                         "num_cores": 2,
                         "memory_mb": 8192,

--- a/cmd/test/fixtures/pause-cluster.json
+++ b/cmd/test/fixtures/pause-cluster.json
@@ -11,6 +11,7 @@
                 "cluster_type": "SYNCHRONOUS",
                 "num_nodes": 1,
                 "fault_tolerance": "NONE",
+                "num_faults_to_tolerate": 0,
                 "node_info": {
                     "num_cores": 2,
                     "memory_mb": 8192,

--- a/cmd/test/fixtures/paused-cluster.json
+++ b/cmd/test/fixtures/paused-cluster.json
@@ -12,6 +12,7 @@
                     "cluster_type": "SYNCHRONOUS",
                     "num_nodes": 1,
                     "fault_tolerance": "NONE",
+                    "num_faults_to_tolerate": 0,
                     "node_info": {
                         "num_cores": 2,
                         "memory_mb": 8192,

--- a/cmd/test/fixtures/pausing-cluster.json
+++ b/cmd/test/fixtures/pausing-cluster.json
@@ -12,6 +12,7 @@
                     "cluster_type": "SYNCHRONOUS",
                     "num_nodes": 1,
                     "fault_tolerance": "NONE",
+                    "num_faults_to_tolerate": 0,
                     "node_info": {
                         "num_cores": 2,
                         "memory_mb": 8192,

--- a/cmd/test/fixtures/resume-cluster.json
+++ b/cmd/test/fixtures/resume-cluster.json
@@ -11,6 +11,7 @@
                 "cluster_type": "SYNCHRONOUS",
                 "num_nodes": 1,
                 "fault_tolerance": "NONE",
+                "num_faults_to_tolerate": 0,
                 "node_info": {
                     "num_cores": 2,
                     "memory_mb": 8192,

--- a/cmd/test/fixtures/resume-queue-cluster.json
+++ b/cmd/test/fixtures/resume-queue-cluster.json
@@ -11,6 +11,7 @@
                 "cluster_type": "SYNCHRONOUS",
                 "num_nodes": 1,
                 "fault_tolerance": "NONE",
+                "num_faults_to_tolerate": 0,
                 "node_info": {
                     "num_cores": 2,
                     "memory_mb": 8192,

--- a/cmd/util/feature_flags.go
+++ b/cmd/util/feature_flags.go
@@ -31,6 +31,7 @@ const (
 	TOOLS               FeatureFlag = "TOOLS"
 	AZURE_CIDR_ALLOWED  FeatureFlag = "AZURE_CIDR_ALLOWED"
 	ENTERPRISE_SECURITY FeatureFlag = "ENTERPRISE_SECURITY"
+	CLUSTER_RF          FeatureFlag = "CLUSTER_RF"
 )
 
 func (f FeatureFlag) String() string {

--- a/cmd/util/util.go
+++ b/cmd/util/util.go
@@ -48,7 +48,27 @@ func GetClusterTier(tierCli string) (string, error) {
 		return "FREE", nil
 	}
 
-	return "", fmt.Errorf("The tier must be either 'Sandbox' or 'Dedicated'")
+	return "", fmt.Errorf("the tier must be either 'Sandbox' or 'Dedicated'")
+}
+
+func ValidateNumFaultsToTolerate(numFaultsToTolerate int32, faultTolerance ybmclient.ClusterFaultTolerance) (bool, error) {
+	if numFaultsToTolerate < 0 || numFaultsToTolerate > 3 {
+		return false, fmt.Errorf("number of faults to tolerate must be between 0 and 3")
+	}
+	if faultTolerance == ybmclient.CLUSTERFAULTTOLERANCE_NONE && numFaultsToTolerate != 0 {
+		return false, fmt.Errorf("number of faults to tolerate must be 0 for fault tolerance level 'NONE'")
+	}
+	if faultTolerance == ybmclient.CLUSTERFAULTTOLERANCE_NODE && numFaultsToTolerate < 1 {
+		return false, fmt.Errorf("number of faults to tolerate must be greater than 0 for fault tolerance level 'NODE'")
+	}
+	if faultTolerance == ybmclient.CLUSTERFAULTTOLERANCE_REGION && numFaultsToTolerate < 1 {
+		return false, fmt.Errorf("number of faults to tolerate must be greater than 0 for fault tolerance level 'REGION'")
+	}
+	if faultTolerance == ybmclient.CLUSTERFAULTTOLERANCE_ZONE && numFaultsToTolerate != 1 {
+		return false, fmt.Errorf("number of faults to tolerate must be 1 for fault tolerance level 'ZONE'")
+	}
+
+	return true, nil
 }
 
 func ValidateCIDR(cidr string) (bool, error) {
@@ -68,7 +88,7 @@ func ExtractJwtClaims(tokenStr string) (jwt.MapClaims, error) {
 	if _, ok := token.Claims.(jwt.MapClaims); ok {
 		return token.Claims.(jwt.MapClaims), nil
 	}
-	return nil, errors.New("Unable to extract claims from token")
+	return nil, errors.New("unable to extract claims from token")
 }
 
 func IsJwtTokenExpiredWithTime(tokenStr string, now time.Time) (bool, error) {

--- a/docs/ybm_cluster_create.md
+++ b/docs/ybm_cluster_create.md
@@ -27,7 +27,7 @@ ybm cluster create [flags]
                                      	For GCP:
                                      	cloud-provider=GCP,gcp-resource-id=<resource-id>,gcp-service-account-path=<service-account-path>.
                                      	If specified, all parameters for that provider are mandatory.
-      --fault-tolerance string       [OPTIONAL] The fault tolerance of the cluster. The possible values are NONE, ZONE and REGION. Default NONE.
+      --fault-tolerance string       [OPTIONAL] The fault tolerance domain of the cluster. The possible values are NONE, ZONE and REGION. Default NONE.
       --node-config stringToInt      [OPTIONAL] Configuration of the cluster nodes. Please provide key value pairs num-cores=<num-cores>,disk-size-gb=<disk-size-gb>,disk-iops=<disk-iops> as the value. If specified, num-cores is mandatory, while disk-size-gb and disk-iops are optional. (default [])
       --region-info stringArray      [OPTIONAL] Region information for the cluster. Please provide key value pairs region=<region-name>,num-nodes=<number-of-nodes>,vpc=<vpc-name> as the value. If specified, region and num-nodes are mandatory, vpc is optional. Information about multiple regions can be specified by using multiple --region-info arguments. Default if not specified is us-west-2 AWS region.
   -h, --help                         help for create

--- a/docs/ybm_cluster_encryption.md
+++ b/docs/ybm_cluster_encryption.md
@@ -35,5 +35,5 @@ ybm cluster encryption [flags]
 * [ybm cluster](ybm_cluster.md)	 - Manage cluster operations
 * [ybm cluster encryption list](ybm_cluster_encryption_list.md)	 - List Encryption at Rest (EaR) configurations for a cluster
 * [ybm cluster encryption update](ybm_cluster_encryption_update.md)	 - Update Encryption at Rest (EaR) configurations for a cluster
-* [ybm cluster encryption update-state](ybm_cluster_encryption_update-state.md) - Update Encryption at Rest (EaR) state for a cluster
+* [ybm cluster encryption update-state](ybm_cluster_encryption_update-state.md)	 - Update Encryption at Rest (EaR) state for a cluster
 

--- a/docs/ybm_cluster_encryption_update-state.md
+++ b/docs/ybm_cluster_encryption_update-state.md
@@ -35,3 +35,4 @@ ybm cluster encryption update-state [flags]
 ### SEE ALSO
 
 * [ybm cluster encryption](ybm_cluster_encryption.md)	 - Manage Encryption at Rest (EaR) for a cluster
+

--- a/docs/ybm_cluster_update.md
+++ b/docs/ybm_cluster_update.md
@@ -18,7 +18,7 @@ ybm cluster update [flags]
       --cluster-tier string       [OPTIONAL] The tier of the cluster. Sandbox or Dedicated.
       --cluster-type string       [OPTIONAL] Cluster replication type. SYNCHRONOUS or GEO_PARTITIONED.
       --database-version string   [OPTIONAL] The database version of the cluster. Production or Innovation or Preview.
-      --fault-tolerance string    [OPTIONAL] The fault tolerance of the cluster. The possible values are NONE, ZONE and REGION.
+      --fault-tolerance string    [OPTIONAL] The fault tolerance domain of the cluster. The possible values are NONE, ZONE and REGION.
   -h, --help                      help for update
       --new-name string           [OPTIONAL] The new name to be given to the cluster.
       --node-config stringToInt   [OPTIONAL] Configuration of the cluster nodes. Please provide key value pairs num-cores=<num-cores>,disk-size-gb=<disk-size-gb>,disk-iops=<disk-iops> as the value. If provided, num-cores is mandatory, while disk-size-gb and disk-iops are optional. (default [])

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -240,6 +240,15 @@ func (a *AuthApiClient) CreateClusterSpec(cmd *cobra.Command, regionInfoList []m
 		faultTolerance, _ := cmd.Flags().GetString("fault-tolerance")
 		clusterInfo.SetFaultTolerance(ybmclient.ClusterFaultTolerance(faultTolerance))
 	}
+	if util.IsFeatureFlagEnabled(util.CLUSTER_RF) {
+		if cmd.Flags().Changed("num-faults-to-tolerate") {
+			numFaultsToTolerate, _ := cmd.Flags().GetInt32("num-faults-to-tolerate")
+			if valid, err := util.ValidateNumFaultsToTolerate(numFaultsToTolerate, clusterInfo.GetFaultTolerance()); !valid {
+				return nil, err
+			}
+			clusterInfo.SetNumFaultsToTolerate(numFaultsToTolerate)
+		}
+	}
 	if util.IsFeatureFlagEnabled(util.ENTERPRISE_SECURITY) {
 		if cmd.Flags().Changed("enterprise-security") {
 			enterpriseSecurity, _ := cmd.Flags().GetBool("enterprise-security")

--- a/internal/formatter/clusters.go
+++ b/internal/formatter/clusters.go
@@ -26,6 +26,7 @@ import (
 	"github.com/enescakir/emoji"
 	"github.com/inhies/go-bytesize"
 	"github.com/sirupsen/logrus"
+	"github.com/yugabyte/ybm-cli/cmd/util"
 	ybmclient "github.com/yugabyte/yugabytedb-managed-go-client-internal"
 	"golang.org/x/exp/maps"
 )
@@ -181,6 +182,10 @@ func (c *ClusterContext) Tier() string {
 	return "Dedicated"
 }
 func (c *ClusterContext) FaultTolerance() string {
+	if util.IsFeatureFlagEnabled(util.CLUSTER_RF) {
+		rf := *c.c.GetSpec().ClusterInfo.NumFaultsToTolerate.Get()*2 + 1
+		return fmt.Sprintf("%s, RF %d", string(c.c.GetSpec().ClusterInfo.FaultTolerance), rf)
+	}
 	return string(c.c.GetSpec().ClusterInfo.FaultTolerance)
 }
 


### PR DESCRIPTION
This PR adds functionality for specifying the number of faults to tolerate for the domain specified by the fault tolerance. It also adds another functionality of explicitly showing the preferred region, if present using a star.

<img width="1223" alt="Screenshot 2023-08-18 at 12 16 45 PM" src="https://github.com/yugabyte/ybm-cli/assets/14933889/a7814f5b-0115-4dd2-a003-45a7d056bff6">
