### PR TITLE
[CLOUDGA-16256] Added billing usage API support to cli 

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,6 +35,7 @@ import (
 	"github.com/yugabyte/ybm-cli/cmd/role"
 	"github.com/yugabyte/ybm-cli/cmd/signup"
 	"github.com/yugabyte/ybm-cli/cmd/tools"
+	"github.com/yugabyte/ybm-cli/cmd/usage"
 	"github.com/yugabyte/ybm-cli/cmd/user"
 	"github.com/yugabyte/ybm-cli/cmd/util"
 	"github.com/yugabyte/ybm-cli/cmd/vpc"
@@ -123,6 +124,7 @@ func init() {
 
 	rootCmd.AddCommand(cluster.ClusterCmd)
 	rootCmd.AddCommand(backup.BackupCmd)
+	rootCmd.AddCommand(usage.UsageCmd)
 	rootCmd.AddCommand(nal.NalCmd)
 	rootCmd.AddCommand(permission.ResourcePermissionsCmd)
 	rootCmd.AddCommand(vpc.VPCCmd)

--- a/cmd/usage/usage.go
+++ b/cmd/usage/usage.go
@@ -1,0 +1,239 @@
+// Licensed to Yugabyte, Inc. under one or more contributor license
+// agreements. See the NOTICE file distributed with this work for
+// additional information regarding copyright ownership. Yugabyte
+// licenses this file to you under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package usage
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	ybmAuthClient "github.com/yugabyte/ybm-cli/internal/client"
+	"github.com/yugabyte/ybm-cli/internal/formatter"
+	ybmclient "github.com/yugabyte/yugabytedb-managed-go-client-internal"
+)
+
+var UsageCmd = &cobra.Command{
+	Use:   "usage",
+	Short: "Billing usage for the account in YugabyteDB Managed",
+	Long:  "Billing usage for the account in YugabyteDB Managed",
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Help()
+	},
+}
+
+var getCmd = &cobra.Command{
+	Use:   "get",
+	Short: "View billing usage data available for the account in YugabyteDB Managed",
+	Long:  "View billing usage data available for the account in YugabyteDB Managed",
+	Run: func(cmd *cobra.Command, args []string) {
+		authApi, err := ybmAuthClient.NewAuthApiClient()
+		if err != nil {
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
+		}
+		authApi.GetInfo("", "")
+		startDate, _ := cmd.Flags().GetString("start")
+		endDate, _ := cmd.Flags().GetString("end")
+		outputFormat, _ := cmd.Flags().GetString("output-format")
+		outputFile, _ := cmd.Flags().GetString("output-file")
+		clusters, _ := cmd.Flags().GetStringArray("cluster-name")
+
+		if startDate == "" || endDate == "" {
+			// If either start date or end date is missing, throw an error
+			logrus.Fatalf("Both start date and end date are required.\n")
+		}
+
+		// Validate start date and end date
+		startDateTime, err := parseAndFormatDate(startDate)
+		if err != nil {
+			logrus.Fatalf("Invalid start date format. Use either RFC3339 format (e.g., '2023-09-01T12:30:45.000Z') or 'yyyy-MM-dd' format (e.g., '2023-09-01').\n")
+		}
+
+		endDateTime, err := parseAndFormatDate(endDate)
+		if err != nil {
+			logrus.Fatalf("Invalid end date format. Use either RFC3339 format (e.g., '2023-09-01T12:30:45.000Z') or 'yyyy-MM-dd' format (e.g., '2023-09-01').\n")
+		}
+
+		if startDateTime.After(endDateTime) {
+			logrus.Fatalf("Start date must be before end date.")
+		}
+
+		startDate = startDateTime.Format("2006-01-02T15:04:05.000Z")
+		endDate = endDateTime.Format("2006-01-02T15:04:05.000Z")
+
+		// Assigning default value to filename if not specified
+		outputFileFormat := "usage_%s_%s"
+		if outputFile == "" {
+			startDateComponents := startDateTime.Format("20060102T150405") // Format as YYYYMMDDHHmmSS
+			endDateComponents := endDateTime.Format("20060102T150405")     // Format as YYYYMMDDHHmmSS
+			outputFile = fmt.Sprintf(outputFileFormat, startDateComponents, endDateComponents)
+		}
+
+		// Check if the file already exists
+		if _, err := os.Stat(outputFile); err == nil {
+			logrus.Fatalf("File %s already exists. Please choose a different output file name.\n", formatter.Colorize(outputFile, formatter.GREEN_COLOR))
+		}
+
+		respC, r, err := authApi.ListClustersByDateRange(startDate, endDate).Execute()
+		if err != nil {
+			logrus.Debugf("Full HTTP response: %v", r)
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
+		}
+		clusterData := respC.Data.GetClusters()
+		var clusterUUIDMap = make(map[string]string)
+
+		for _, cluster := range clusterData {
+			clusterName := cluster.Name
+			clusterUUIDMap[clusterName] = cluster.Id
+		}
+
+		var selectedUUIDs []string
+		if len(clusters) > 0 {
+			selectedUUIDs = make([]string, 0, len(clusters))
+			for _, clusterName := range clusters {
+				if clusterID, ok := clusterUUIDMap[clusterName]; ok {
+					selectedUUIDs = append(selectedUUIDs, clusterID)
+				} else {
+					logrus.Fatalf("Cluster name '%s' not found within the specified time range.\n", clusterName)
+				}
+			}
+		} else {
+			selectedUUIDs = nil
+		}
+
+		resp, r, err := authApi.GetBillingUsage(startDate, endDate, selectedUUIDs).Execute()
+
+		if err != nil {
+			logrus.Debugf("Full HTTP response: %v", r)
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
+		}
+		usageData := resp.GetData()
+
+		switch strings.ToLower(outputFormat) {
+		case "csv":
+			if err := outputCSV(usageData, outputFile); err != nil {
+				logrus.Fatalf("Error outputting CSV: %v", err)
+			}
+		case "json":
+			if err := outputJSON(usageData, outputFile); err != nil {
+				logrus.Fatalf("Error outputting JSON: %v", err)
+			}
+		default:
+			logrus.Warnf("Unsupported format: %s. Defaulting to CSV.", outputFormat)
+			if err := outputCSV(usageData, outputFile); err != nil {
+				logrus.Fatalf("Error outputting CSV: %v", err)
+			}
+		}
+	},
+}
+
+func parseAndFormatDate(dateStr string) (time.Time, error) {
+	// Try parsing in RFC3339 format
+	parsedDate, err := time.Parse(time.RFC3339, dateStr)
+	if err != nil {
+		// If parsing fails, try parsing in "yyyy-MM-dd" format
+		parsedDate, err = time.Parse("2006-01-02", dateStr)
+		if err != nil {
+			return time.Time{}, err
+		}
+	}
+
+	return parsedDate, nil
+}
+
+func outputCSV(resp ybmclient.BillingUsageData, filename string) error {
+	file, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	writer := csv.NewWriter(file)
+	defer writer.Flush()
+
+	dimensionHeaders := []string{"Date"}
+	for _, dimension := range resp.GetDimensions() {
+		dimensionHeaders = append(dimensionHeaders, string(dimension.GetName())+"_Daily", string(dimension.GetName())+"_Cumulative")
+	}
+
+	err = writer.Write(dimensionHeaders)
+	if err != nil {
+		return err
+	}
+
+	for _, dataPoint := range resp.GetDimensions()[0].DataPoints {
+		row := []string{dataPoint.GetStartDate()}
+
+		for _, dimension := range resp.GetDimensions() {
+			var found bool
+			for _, point := range dimension.DataPoints {
+				if point.StartDate == dataPoint.StartDate {
+					row = append(row, fmt.Sprintf("%f", *point.DailyUsage))
+					row = append(row, fmt.Sprintf("%f", *point.CumulativeUsage))
+					found = true
+					break
+				}
+			}
+
+			// If no data found for the current dimension, add placeholders
+			if !found {
+				row = append(row, "0.000000", "0.000000")
+			}
+		}
+
+		err := writer.Write(row)
+		if err != nil {
+			return err
+		}
+	}
+
+	fmt.Printf("CSV data written to %s.csv.\n", formatter.Colorize(filename, formatter.GREEN_COLOR))
+	return nil
+}
+
+func outputJSON(data interface{}, filename string) error {
+	jsonData, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal data to JSON: %v", err)
+	}
+
+	file, err := os.Create(filename)
+	if err != nil {
+		return fmt.Errorf("failed to create or open JSON file: %v", err)
+	}
+	defer file.Close()
+
+	_, err = file.Write(jsonData)
+	if err != nil {
+		return fmt.Errorf("failed to write JSON data to file: %v", err)
+	}
+
+	fmt.Printf("JSON data written to %s.json.\n", formatter.Colorize(filename, formatter.GREEN_COLOR))
+	return nil
+}
+
+func init() {
+	UsageCmd.AddCommand(getCmd)
+	getCmd.Flags().String("start", "", "[REQUIRED] Start date in RFC3339 format (e.g., '2023-09-01T12:30:45.000Z') or 'yyyy-MM-dd' format (e.g., '2023-09-01').")
+	getCmd.Flags().String("end", "", "[REQUIRED] End date in RFC3339 format (e.g., '2023-09-30T23:59:59.999Z') or 'yyyy-MM-dd' format (e.g., '2023-09-30').")
+	getCmd.Flags().StringArray("cluster-name", []string{}, "[REQUIRED] Cluster names. Multiple names can be specified by using multiple --cluster-name arguments.")
+	getCmd.Flags().String("output-format", "csv", "[OPTIONAL] Output format. Possible values: csv, json.")
+	getCmd.Flags().String("output-file", "", "[OPTIONAL] Output filename.")
+}

--- a/docs/ybm.md
+++ b/docs/ybm.md
@@ -37,6 +37,7 @@ ybm [flags]
 * [ybm region](ybm_region.md)	 - Manage cloud regions
 * [ybm role](ybm_role.md)	 - Manage roles
 * [ybm signup](ybm_signup.md)	 - Open a browser to sign up for YugabyteDB Managed
+* [ybm usage](ybm_usage.md)	 - Billing usage for the account in YugabyteDB Managed
 * [ybm user](ybm_user.md)	 - Manage users
 * [ybm vpc](ybm_vpc.md)	 - Manage VPCs
 

--- a/docs/ybm_usage.md
+++ b/docs/ybm_usage.md
@@ -1,0 +1,36 @@
+## ybm usage
+
+Billing usage for the account in YugabyteDB Managed
+
+### Synopsis
+
+Billing usage for the account in YugabyteDB Managed
+
+```
+ybm usage [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for usage
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string      YBM Api Key
+      --config string      config file (default is $HOME/.ybm-cli.yaml)
+      --debug              Use debug mode, same as --logLevel debug
+  -l, --logLevel string    Select the desired log level format(info). Default to info
+      --no-color           Disable colors in output , default to false
+  -o, --output string      Select the desired output format (table, json, pretty). Default to table
+      --timeout duration   Wait command timeout, example: 5m, 1h. (default 168h0m0s)
+      --wait               Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm](ybm.md)	 - ybm - Effortlessly manage your DB infrastructure on YugabyteDB Managed (DBaaS) from command line!
+* [ybm usage get](ybm_usage_get.md)	 - View billing usage data available for the account in YugabyteDB Managed
+

--- a/docs/ybm_usage_get.md
+++ b/docs/ybm_usage_get.md
@@ -1,0 +1,40 @@
+## ybm usage get
+
+View billing usage data available for the account in YugabyteDB Managed
+
+### Synopsis
+
+View billing usage data available for the account in YugabyteDB Managed
+
+```
+ybm usage get [flags]
+```
+
+### Options
+
+```
+      --cluster-name stringArray   [REQUIRED] Cluster names. Multiple names can be specified by using multiple --cluster-name arguments.
+      --end string                 [REQUIRED] End date in RFC3339 format (e.g., '2023-09-30T23:59:59.999Z') or 'yyyy-MM-dd' format (e.g., '2023-09-30').
+  -h, --help                       help for get
+      --output-file string         [OPTIONAL] Output filename.
+      --output-format string       [OPTIONAL] Output format. Possible values: csv, json. (default "csv")
+      --start string               [REQUIRED] Start date in RFC3339 format (e.g., '2023-09-01T12:30:45.000Z') or 'yyyy-MM-dd' format (e.g., '2023-09-01').
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string      YBM Api Key
+      --config string      config file (default is $HOME/.ybm-cli.yaml)
+      --debug              Use debug mode, same as --logLevel debug
+  -l, --logLevel string    Select the desired log level format(info). Default to info
+      --no-color           Disable colors in output , default to false
+  -o, --output string      Select the desired output format (table, json, pretty). Default to table
+      --timeout duration   Wait command timeout, example: 5m, 1h. (default 168h0m0s)
+      --wait               Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm usage](ybm_usage.md)	 - Billing usage for the account in YugabyteDB Managed
+

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.15.0
 	github.com/t-tomalak/logrus-easy-formatter v0.0.0-20190827215021-c074f06c5816
-	github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20230915094706-0a165a0d7d08
+	github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20231005213122-c1389755cc7f
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9
 	golang.org/x/mod v0.12.0
 	golang.org/x/term v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -278,6 +278,10 @@ github.com/t-tomalak/logrus-easy-formatter v0.0.0-20190827215021-c074f06c5816 h1
 github.com/t-tomalak/logrus-easy-formatter v0.0.0-20190827215021-c074f06c5816/go.mod h1:tzym/CEb5jnFI+Q0k4Qq3+LvRF4gO3E2pxS8fHP8jcA=
 github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20230915094706-0a165a0d7d08 h1:ohLS4WahD92jv8Th6tS38VGsTD3767dPnNj/rN5RreM=
 github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20230915094706-0a165a0d7d08/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20231002173116-4bef65a4f62e h1:pfJyYqKlg3XDhUeD/e3uEasCAVFziKbkTET+SjJS8QI=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20231002173116-4bef65a4f62e/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20231005213122-c1389755cc7f h1:6JM4ixKyL6NNjs1iib6HIdZmNNTL8e1SAqfGmhADQk4=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20231005213122-c1389755cc7f/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -640,6 +640,14 @@ func (a *AuthApiClient) ListClusterNetworkAllowLists(clusterId string) ybmclient
 	return a.ApiClient.ClusterApi.ListClusterNetworkAllowLists(a.ctx, a.AccountID, a.ProjectID, clusterId)
 }
 
+func (a *AuthApiClient) GetBillingUsage(startTimestamp string, endTimestamp string, clusterIds []string) ybmclient.ApiGetBillingUsageRequest {
+	return a.ApiClient.BillingApi.GetBillingUsage(a.ctx, a.AccountID).StartTimestamp(startTimestamp).EndTimestamp(endTimestamp).Granularity(ybmclient.GRANULARITYENUM_DAILY).ClusterIds(clusterIds)
+}
+
+func (a *AuthApiClient) ListClustersByDateRange(startTimestamp string, endTimestamp string) ybmclient.ApiListClustersByDateRangeRequest {
+	return a.ApiClient.BillingApi.ListClustersByDateRange(a.ctx, a.AccountID).StartTimestamp(startTimestamp).EndTimestamp(endTimestamp).Tier(ybmclient.CLUSTERTIER_PAID)
+}
+
 func (a *AuthApiClient) ListClusterCMKs(clusterId string) ybmclient.ApiGetClusterCMKRequest {
 	return a.ApiClient.ClusterApi.GetClusterCMK(a.ctx, a.AccountID, a.ProjectID, clusterId)
 }


### PR DESCRIPTION
## Summary

Added billing usage API support to CLI. 

This API lets the user track the billing usage between the specified date interval by showing usage across 8 billing dimensions.

The data is exported as csv or json. 

##  Command line

The command takes the following inputs from the user:

1. `Start date and end date`: _Mandatory_ parameters in two supported formats : `yyyy-MM-dd`  or  `RFC3339 format` (e.g., '2023-09-01T12:30:45.000Z')`
2. `Format`: _Optional_ parameter that specifies the output format of the exported data - csv or json. 
Default value: `csv`
3. `Output`: _Optional_ parameter that specified the name of the output file. 
Default value: `usage`.
4. `cluster-name`: _Optional_ list parameter for cluster names. If specified, then the usage data is aggregated across these clusters.
Default value: `null`. This implies that data will be aggregated across all clusters.

##  Usage 

`
./ybm usage get --start 2022-10-12T15:30:00Z --end 2022-12-13T15:30:00Z --output-format json --output-file usage5 --cluster-name willing-walrus --cluster-name courageous-jellyfish
`


##  Screenshots
<img width="1010" alt="Screenshot 2023-10-10 at 3 43 55 PM" src="https://github.com/yugabyte/ybm-cli/assets/79891485/20f22a16-997a-4b97-bb10-0244d53c4eaa">

## Output

#### CSV output

<img width="1728" alt="Screenshot 2023-10-10 at 5 47 28 AM" src="https://github.com/yugabyte/ybm-cli/assets/79891485/80fa01db-32a5-4821-a6eb-861817346f8b">


#### JSON output

<img width="1728" alt="Screenshot 2023-10-04 at 11 36 49 AM" src="https://github.com/yugabyte/ybm-cli/assets/79891485/c24214e4-e905-425a-97fc-96a975fdfe59">

```
{
  "cluster_ids": [],
  "dimensions": [
    {
      "cumulative_usage": 0,
      "data_points": [
        {
          "cumulative_usage": 0,
          "daily_usage": 0,
          "end_date": "2022-10-13",
          "start_date": "2022-10-12"
        },
        {
          "cumulative_usage": 0,
          "daily_usage": 0,
          "end_date": "2022-10-14",
          "start_date": "2022-10-13"
        }
      ],
      "name": "VCPUS",
      "unit": "HOURS"
    },
    {
      "cumulative_usage": 0,
      "data_points": [
        {
          "cumulative_usage": 0,
          "daily_usage": 0,
          "end_date": "2022-10-13",
          "start_date": "2022-10-12"
        },
        {
          "cumulative_usage": 0,
          "daily_usage": 0,
          "end_date": "2022-10-14",
          "start_date": "2022-10-13"
        }
      ],
      "name": "DISK_STORAGE",
      "unit": "GB_HOURS"
    },
    {
      "cumulative_usage": 0,
      "data_points": [
        {
          "cumulative_usage": 0,
          "daily_usage": 0,
          "end_date": "2022-10-13",
          "start_date": "2022-10-12"
        },
        {
          "cumulative_usage": 0,
          "daily_usage": 0,
          "end_date": "2022-10-14",
          "start_date": "2022-10-13"
        }
      ],
      "name": "DISK_IOPS",
      "unit": "NONE"
    },
    {
      "cumulative_usage": 0,
      "data_points": [
        {
          "cumulative_usage": 0,
          "daily_usage": 0,
          "end_date": "2022-10-13",
          "start_date": "2022-10-12"
        },
        {
          "cumulative_usage": 0,
          "daily_usage": 0,
          "end_date": "2022-10-14",
          "start_date": "2022-10-13"
        }
      ],
      "name": "BACKUP_STORAGE",
      "unit": "GB_HOURS"
    },
    {
      "cumulative_usage": 0,
      "data_points": [
        {
          "cumulative_usage": 0,
          "daily_usage": 0,
          "end_date": "2022-10-13",
          "start_date": "2022-10-12"
        },
        {
          "cumulative_usage": 0,
          "daily_usage": 0,
          "end_date": "2022-10-14",
          "start_date": "2022-10-13"
        }
      ],
      "name": "DATA_TRANSFER_WITHIN_REGION",
      "unit": "GB"
    },
    {
      "cumulative_usage": 0,
      "data_points": [
        {
          "cumulative_usage": 0,
          "daily_usage": 0,
          "end_date": "2022-10-13",
          "start_date": "2022-10-12"
        },
        {
          "cumulative_usage": 0,
          "daily_usage": 0,
          "end_date": "2022-10-14",
          "start_date": "2022-10-13"
        }
      ],
      "name": "DATA_TRANSFER_CROSS_REGION_APAC",
      "unit": "GB"
    },
    {
      "cumulative_usage": 0,
      "data_points": [
        {
          "cumulative_usage": 0,
          "daily_usage": 0,
          "end_date": "2022-10-13",
          "start_date": "2022-10-12"
        },
        {
          "cumulative_usage": 0,
          "daily_usage": 0,
          "end_date": "2022-10-14",
          "start_date": "2022-10-13"
        }
      ],
      "name": "DATA_TRANSFER_CROSS_REGION_NON_APAC",
      "unit": "GB"
    },
    {
      "cumulative_usage": 0,
      "data_points": [
        {
          "cumulative_usage": 0,
          "daily_usage": 0,
          "end_date": "2022-10-13",
          "start_date": "2022-10-12"
        },
        {
          "cumulative_usage": 0,
          "daily_usage": 0,
          "end_date": "2022-10-14",
          "start_date": "2022-10-13"
        }
      ],
      "name": "DATA_TRANSFER_INTERNET",
      "unit": "GB"
    }
  ],
  "end_timestamp": "2022-10-13T15:30:00.000Z",
  "granularity": "DAILY",
  "start_timestamp": "2022-10-12T15:30:00.000Z"
}
```
 