### PR TITLE
Spend Tracking : Refactoring and added UTs for spend tracking

### DIFF
--- a/cmd/test/fixtures/list-clusters-date-range.json
+++ b/cmd/test/fixtures/list-clusters-date-range.json
@@ -1,0 +1,20 @@
+{
+    "data": {
+        "start_timestamp": "2023-08-13T18:30Z",
+        "end_timestamp": "2023-08-15T18:30Z",
+        "clusters": [
+            {
+                "id": "685fb1e0-8095-488a-8d62-7097d29c40ba",
+                "name": "courageous-jellyfish",
+                "is_deleted": true,
+                "cloud": "AWS"
+            },
+            {
+                "id": "70a6592e-21c3-4d13-b089-152cf62f02cb",
+                "name": "willing-walrus",
+                "is_deleted": false,
+                "cloud": "GCP"
+            }
+        ]
+    }
+}

--- a/cmd/test/fixtures/usage-data.json
+++ b/cmd/test/fixtures/usage-data.json
@@ -1,0 +1,213 @@
+{
+    "data": {
+      "granularity": "DAILY",
+      "start_timestamp": "2023-08-13T18:30:00.000Z",
+      "end_timestamp": "2023-08-15T18:30:00.000Z",
+      "cluster_ids": [
+        "courageous-jellyfish",
+        "willing-walrus"
+      ],
+      "dimensions": [
+        {
+          "name": "VCPUS",
+          "unit": "HOURS",
+          "cumulative_usage": 120.52,
+          "data_points": [
+            {
+              "start_date": "2023-08-13",
+              "end_date": "2023-08-14",
+              "daily_usage": 120.52,
+              "cumulative_usage": 120.52
+            },
+            {
+              "start_date": "2023-08-14",
+              "end_date": "2023-08-15",
+              "daily_usage": 0,
+              "cumulative_usage": 120.52
+            },
+            {
+              "start_date": "2023-08-15",
+              "end_date": "2023-08-16",
+              "daily_usage": 0,
+              "cumulative_usage": 120.52
+            }
+          ]
+        },
+        {
+          "name": "DISK_STORAGE",
+          "unit": "GB_HOURS",
+          "cumulative_usage": 6026,
+          "data_points": [
+            {
+              "start_date": "2023-08-13",
+              "end_date": "2023-08-14",
+              "daily_usage": 6026,
+              "cumulative_usage": 6026
+            },
+            {
+              "start_date": "2023-08-14",
+              "end_date": "2023-08-15",
+              "daily_usage": 0,
+              "cumulative_usage": 6026
+            },
+            {
+              "start_date": "2023-08-15",
+              "end_date": "2023-08-16",
+              "daily_usage": 0,
+              "cumulative_usage": 6026
+            }
+          ]
+        },
+        {
+          "name": "DISK_IOPS",
+          "unit": "NONE",
+          "cumulative_usage": 0,
+          "data_points": [
+            {
+              "start_date": "2023-08-13",
+              "end_date": "2023-08-14",
+              "daily_usage": 0,
+              "cumulative_usage": 0
+            },
+            {
+              "start_date": "2023-08-14",
+              "end_date": "2023-08-15",
+              "daily_usage": 0,
+              "cumulative_usage": 0
+            },
+            {
+              "start_date": "2023-08-15",
+              "end_date": "2023-08-16",
+              "daily_usage": 0,
+              "cumulative_usage": 0
+            }
+          ]
+        },
+        {
+          "name": "BACKUP_STORAGE",
+          "unit": "GB_HOURS",
+          "cumulative_usage": 0,
+          "data_points": [
+            {
+              "start_date": "2023-08-13",
+              "end_date": "2023-08-14",
+              "daily_usage": 0,
+              "cumulative_usage": 0
+            },
+            {
+              "start_date": "2023-08-14",
+              "end_date": "2023-08-15",
+              "daily_usage": 0,
+              "cumulative_usage": 0
+            },
+            {
+              "start_date": "2023-08-15",
+              "end_date": "2023-08-16",
+              "daily_usage": 0,
+              "cumulative_usage": 0
+            }
+          ]
+        },
+        {
+          "name": "DATA_TRANSFER_WITHIN_REGION",
+          "unit": "GB",
+          "cumulative_usage": 1.9622329501,
+          "data_points": [
+            {
+              "start_date": "2023-08-13",
+              "end_date": "2023-08-14",
+              "daily_usage": 1.9622329501,
+              "cumulative_usage": 1.9622329501
+            },
+            {
+              "start_date": "2023-08-14",
+              "end_date": "2023-08-15",
+              "daily_usage": 0,
+              "cumulative_usage": 1.9622329501
+            },
+            {
+              "start_date": "2023-08-15",
+              "end_date": "2023-08-16",
+              "daily_usage": 0,
+              "cumulative_usage": 1.9622329501
+            }
+          ]
+        },
+        {
+          "name": "DATA_TRANSFER_CROSS_REGION_APAC",
+          "unit": "GB",
+          "cumulative_usage": 0,
+          "data_points": [
+            {
+              "start_date": "2023-08-13",
+              "end_date": "2023-08-14",
+              "daily_usage": 0,
+              "cumulative_usage": 0
+            },
+            {
+              "start_date": "2023-08-14",
+              "end_date": "2023-08-15",
+              "daily_usage": 0,
+              "cumulative_usage": 0
+            },
+            {
+              "start_date": "2023-08-15",
+              "end_date": "2023-08-16",
+              "daily_usage": 0,
+              "cumulative_usage": 0
+            }
+          ]
+        },
+        {
+          "name": "DATA_TRANSFER_CROSS_REGION_NON_APAC",
+          "unit": "GB",
+          "cumulative_usage": 0.1733244699,
+          "data_points": [
+            {
+              "start_date": "2023-08-13",
+              "end_date": "2023-08-14",
+              "daily_usage": 0.1733244699,
+              "cumulative_usage": 0.1733244699
+            },
+            {
+              "start_date": "2023-08-14",
+              "end_date": "2023-08-15",
+              "daily_usage": 0,
+              "cumulative_usage": 0.1733244699
+            },
+            {
+              "start_date": "2023-08-15",
+              "end_date": "2023-08-16",
+              "daily_usage": 0,
+              "cumulative_usage": 0.1733244699
+            }
+          ]
+        },
+        {
+          "name": "DATA_TRANSFER_INTERNET",
+          "unit": "GB",
+          "cumulative_usage": 0.1190233121,
+          "data_points": [
+            {
+              "start_date": "2023-08-13",
+              "end_date": "2023-08-14",
+              "daily_usage": 0.1189816631,
+              "cumulative_usage": 0.1189816631
+            },
+            {
+              "start_date": "2023-08-14",
+              "end_date": "2023-08-15",
+              "daily_usage": 0.0000233949,
+              "cumulative_usage": 0.119005058
+            },
+            {
+              "start_date": "2023-08-15",
+              "end_date": "2023-08-16",
+              "daily_usage": 0.0000182541,
+              "cumulative_usage": 0.1190233121
+            }
+          ]
+        }
+      ]
+    }
+  }

--- a/cmd/usage/usage.go
+++ b/cmd/usage/usage.go
@@ -20,6 +20,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -54,68 +56,25 @@ var getCmd = &cobra.Command{
 		outputFormat, _ := cmd.Flags().GetString("output-format")
 		outputFile, _ := cmd.Flags().GetString("output-file")
 		clusters, _ := cmd.Flags().GetStringArray("cluster-name")
+		force := cmd.Flags().Changed("force")
 
-		if startDate == "" || endDate == "" {
-			// If either start date or end date is missing, throw an error
-			logrus.Fatalf("Both start date and end date are required.\n")
-		}
-
-		// Validate start date and end date
-		startDateTime, err := parseAndFormatDate(startDate)
+		startDateTime, endDateTime, err := validateDates(startDate, endDate)
 		if err != nil {
-			logrus.Fatalf("Invalid start date format. Use either RFC3339 format (e.g., '2023-09-01T12:30:45.000Z') or 'yyyy-MM-dd' format (e.g., '2023-09-01').\n")
+			logrus.Fatalf("Error: %v\n", err)
 		}
 
-		endDateTime, err := parseAndFormatDate(endDate)
-		if err != nil {
-			logrus.Fatalf("Invalid end date format. Use either RFC3339 format (e.g., '2023-09-01T12:30:45.000Z') or 'yyyy-MM-dd' format (e.g., '2023-09-01').\n")
-		}
-
-		if startDateTime.After(endDateTime) {
-			logrus.Fatalf("Start date must be before end date.")
-		}
-
+		// Format dates
 		startDate = startDateTime.Format("2006-01-02T15:04:05.000Z")
 		endDate = endDateTime.Format("2006-01-02T15:04:05.000Z")
 
-		// Assigning default value to filename if not specified
-		outputFileFormat := "usage_%s_%s"
-		if outputFile == "" {
-			startDateComponents := startDateTime.Format("20060102T150405") // Format as YYYYMMDDHHmmSS
-			endDateComponents := endDateTime.Format("20060102T150405")     // Format as YYYYMMDDHHmmSS
-			outputFile = fmt.Sprintf(outputFileFormat, startDateComponents, endDateComponents)
-		}
-
-		// Check if the file already exists
-		if _, err := os.Stat(outputFile); err == nil {
-			logrus.Fatalf("File %s already exists. Please choose a different output file name.\n", formatter.Colorize(outputFile, formatter.GREEN_COLOR))
-		}
-
-		respC, r, err := authApi.ListClustersByDateRange(startDate, endDate).Execute()
+		combinedFilename, fileExtension, err := checkOutputFile(outputFile, outputFormat, startDateTime, endDateTime, force)
 		if err != nil {
-			logrus.Debugf("Full HTTP response: %v", r)
-			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
-		}
-		clusterData := respC.Data.GetClusters()
-		var clusterUUIDMap = make(map[string]string)
-
-		for _, cluster := range clusterData {
-			clusterName := cluster.Name
-			clusterUUIDMap[clusterName] = cluster.Id
+			logrus.Fatalf("Error: %v", err)
 		}
 
-		var selectedUUIDs []string
-		if len(clusters) > 0 {
-			selectedUUIDs = make([]string, 0, len(clusters))
-			for _, clusterName := range clusters {
-				if clusterID, ok := clusterUUIDMap[clusterName]; ok {
-					selectedUUIDs = append(selectedUUIDs, clusterID)
-				} else {
-					logrus.Fatalf("Cluster name '%s' not found within the specified time range.\n", clusterName)
-				}
-			}
-		} else {
-			selectedUUIDs = nil
+		selectedUUIDs, selectedClusterNames, err := getSelectedUUIDs(startDate, endDate, clusters, authApi)
+		if err != nil {
+			logrus.Fatalf("Error: %v", err)
 		}
 
 		resp, r, err := authApi.GetBillingUsage(startDate, endDate, selectedUUIDs).Execute()
@@ -124,24 +83,141 @@ var getCmd = &cobra.Command{
 			logrus.Debugf("Full HTTP response: %v", r)
 			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
-		usageData := resp.GetData()
 
-		switch strings.ToLower(outputFormat) {
-		case "csv":
-			if err := outputCSV(usageData, outputFile); err != nil {
-				logrus.Fatalf("Error outputting CSV: %v", err)
-			}
-		case "json":
-			if err := outputJSON(usageData, outputFile); err != nil {
-				logrus.Fatalf("Error outputting JSON: %v", err)
-			}
-		default:
-			logrus.Warnf("Unsupported format: %s. Defaulting to CSV.", outputFormat)
-			if err := outputCSV(usageData, outputFile); err != nil {
-				logrus.Fatalf("Error outputting CSV: %v", err)
+		handleOutput(resp, combinedFilename, fileExtension, selectedClusterNames)
+	},
+}
+
+func handleOutput(usageResponse ybmclient.BillingUsageResponse, combinedFilename, fileExtension string, selectedClusterNames []string) {
+	switch fileExtension {
+	case "csv":
+		if err := outputCSV(usageResponse.GetData(), combinedFilename, selectedClusterNames); err != nil {
+			logrus.Fatalf("Error outputting CSV: %v", err)
+		}
+	case "json":
+		usageResponse.Data.Get().SetClusterIds(selectedClusterNames)
+		if err := outputJSON(usageResponse, combinedFilename); err != nil {
+			logrus.Fatalf("Error outputting JSON: %v", err)
+		}
+	default:
+		logrus.Warnf("Unsupported format: %s. Defaulting to CSV.", fileExtension)
+		if err := outputCSV(usageResponse.GetData(), combinedFilename, selectedClusterNames); err != nil {
+			logrus.Fatalf("Error outputting CSV: %v", err)
+		}
+	}
+}
+
+func getSelectedUUIDs(startDate, endDate string, clusters []string, authApi *ybmAuthClient.AuthApiClient) ([]string, []string, error) {
+	respC, r, err := authApi.ListClustersByDateRange(startDate, endDate).Execute()
+	if err != nil {
+		logrus.Debugf("Full HTTP response: %v", r)
+		return nil, nil, fmt.Errorf(ybmAuthClient.GetApiErrorDetails(err))
+	}
+
+	clusterData := respC.Data.GetClusters()
+	clusterUUIDMap := make(map[string]string)
+
+	// Map of <cluster uuid, cluster name> for all clusters
+	for _, cluster := range clusterData {
+		clusterName := cluster.Name
+		clusterUUIDMap[clusterName] = cluster.Id
+	}
+
+	var selectedClusterUUIDs []string
+	var selectedClusterNames []string
+	var notFoundClusters []string
+
+	if len(clusters) > 0 {
+		selectedClusterUUIDs = make([]string, 0, len(clusters))
+		for _, clusterName := range clusters {
+			if clusterID, ok := clusterUUIDMap[clusterName]; ok {
+				selectedClusterUUIDs = append(selectedClusterUUIDs, clusterID)
+				selectedClusterNames = append(selectedClusterNames, clusterName)
+			} else {
+				notFoundClusters = append(notFoundClusters, clusterName)
 			}
 		}
-	},
+	} else { // By default select all clusters
+		for clusterName, _ := range clusterUUIDMap {
+			selectedClusterNames = append(selectedClusterNames, clusterName)
+		}
+	}
+
+	if len(notFoundClusters) > 0 {
+		return nil, nil, fmt.Errorf("clusters '%s' not found within the specified time range", strings.Join(notFoundClusters, ", "))
+	}
+	sort.Strings(selectedClusterNames)
+	return selectedClusterUUIDs, selectedClusterNames, nil
+}
+
+func validateDates(startDate, endDate string) (startDateTime, endDateTime time.Time, err error) {
+	if startDate == "" || endDate == "" {
+		return time.Time{}, time.Time{}, fmt.Errorf("both start date and end date are required")
+	}
+	startDateTime, err = parseAndFormatDate(startDate)
+	if err != nil {
+		return time.Time{}, time.Time{}, fmt.Errorf("invalid start date format. Use either RFC3339 format (e.g., '2023-09-01T12:30:45.000Z') or 'yyyy-MM-dd' format (e.g., '2023-09-01')")
+	}
+
+	endDateTime, err = parseAndFormatDate(endDate)
+	if err != nil {
+		return time.Time{}, time.Time{}, fmt.Errorf("invalid end date format. Use either RFC3339 format (e.g., '2023-09-01T12:30:45.000Z') or 'yyyy-MM-dd' format (e.g., '2023-09-01')")
+	}
+
+	if startDateTime.After(endDateTime) {
+		return time.Time{}, time.Time{}, fmt.Errorf("start date must be before end date")
+	}
+
+	return startDateTime, endDateTime, nil
+}
+
+func checkOutputFile(outputFile, outputFormat string, startDateTime, endDateTime time.Time, force bool) (combinedFilename, fileExtension string, err error) {
+	// Assigning default value to filename if not specified
+	outputFileFormat := "usage_%s_%s"
+	if outputFile == "" {
+		startDateComponents := startDateTime.Format("20060102T150405") // Format as YYYYMMDDHHmmSS
+		endDateComponents := endDateTime.Format("20060102T150405")     // Format as YYYYMMDDHHmmSS
+		outputFile = fmt.Sprintf(outputFileFormat, startDateComponents, endDateComponents)
+	}
+
+	outputFormat = strings.ToLower(outputFormat)
+	combinedFilename = getNormalizedFilePathForFormat(outputFile, outputFormat)
+	fileExtension = strings.ToLower(strings.TrimPrefix(filepath.Ext(combinedFilename), "."))
+
+	if outputFormat != "" && outputFormat != fileExtension {
+		logrus.Warnf("Mismatch between output file extension and output format. Using file extension: %s\n", fileExtension)
+	}
+
+	// Check if the file already exists
+	if !force {
+		if _, err := os.Stat(combinedFilename); err == nil {
+			return "", "", fmt.Errorf("file %s already exists", combinedFilename)
+		}
+	}
+
+	if fileExtension != "csv" && fileExtension != "json" {
+		return "", "", fmt.Errorf("file extension %s is not supported", fileExtension)
+	}
+
+	return combinedFilename, fileExtension, nil
+}
+
+func getNormalizedFilePathForFormat(filePath, outputFormat string) string {
+	filePathWithoutExtension := strings.TrimSuffix(filePath, filepath.Ext(filePath))
+	extension := strings.ToLower(strings.TrimPrefix(filepath.Ext(filePath), "."))
+	validExtensions := map[string]struct{}{"json": {}, "csv": {}}
+	_, isValid := validExtensions[extension]
+	if isValid {
+		return filePathWithoutExtension + "." + extension
+	} else if extension != "" {
+		logrus.Warnf("Unsupported extension type: %s\n", extension)
+	}
+
+	// If extension is not valid and outputFormat is empty, default to "csv"
+	if outputFormat == "" {
+		return filePathWithoutExtension + ".csv"
+	}
+	return filePathWithoutExtension + "." + strings.ToLower(outputFormat)
 }
 
 func parseAndFormatDate(dateStr string) (time.Time, error) {
@@ -158,7 +234,7 @@ func parseAndFormatDate(dateStr string) (time.Time, error) {
 	return parsedDate, nil
 }
 
-func outputCSV(resp ybmclient.BillingUsageData, filename string) error {
+func outputCSV(resp ybmclient.BillingUsageData, filename string, selectedClusterNames []string) error {
 	file, err := os.Create(filename)
 	if err != nil {
 		return err
@@ -168,7 +244,7 @@ func outputCSV(resp ybmclient.BillingUsageData, filename string) error {
 	writer := csv.NewWriter(file)
 	defer writer.Flush()
 
-	dimensionHeaders := []string{"Date"}
+	dimensionHeaders := []string{"Date", "Clusters"}
 	for _, dimension := range resp.GetDimensions() {
 		dimensionHeaders = append(dimensionHeaders, string(dimension.GetName())+"_Daily", string(dimension.GetName())+"_Cumulative")
 	}
@@ -180,21 +256,15 @@ func outputCSV(resp ybmclient.BillingUsageData, filename string) error {
 
 	for _, dataPoint := range resp.GetDimensions()[0].DataPoints {
 		row := []string{dataPoint.GetStartDate()}
+		row = append(row, "'"+strings.Join(selectedClusterNames, "','")+"'")
 
 		for _, dimension := range resp.GetDimensions() {
-			var found bool
 			for _, point := range dimension.DataPoints {
-				if point.StartDate == dataPoint.StartDate {
+				if point.GetStartDate() == dataPoint.GetStartDate() {
 					row = append(row, fmt.Sprintf("%f", *point.DailyUsage))
 					row = append(row, fmt.Sprintf("%f", *point.CumulativeUsage))
-					found = true
 					break
 				}
-			}
-
-			// If no data found for the current dimension, add placeholders
-			if !found {
-				row = append(row, "0.000000", "0.000000")
 			}
 		}
 
@@ -204,7 +274,7 @@ func outputCSV(resp ybmclient.BillingUsageData, filename string) error {
 		}
 	}
 
-	fmt.Printf("CSV data written to %s.csv.\n", formatter.Colorize(filename, formatter.GREEN_COLOR))
+	fmt.Printf("CSV data written to %s\n", formatter.Colorize(filename, formatter.GREEN_COLOR))
 	return nil
 }
 
@@ -225,7 +295,7 @@ func outputJSON(data interface{}, filename string) error {
 		return fmt.Errorf("failed to write JSON data to file: %v", err)
 	}
 
-	fmt.Printf("JSON data written to %s.json.\n", formatter.Colorize(filename, formatter.GREEN_COLOR))
+	fmt.Printf("JSON data written to %s\n", formatter.Colorize(filename, formatter.GREEN_COLOR))
 	return nil
 }
 
@@ -233,7 +303,8 @@ func init() {
 	UsageCmd.AddCommand(getCmd)
 	getCmd.Flags().String("start", "", "[REQUIRED] Start date in RFC3339 format (e.g., '2023-09-01T12:30:45.000Z') or 'yyyy-MM-dd' format (e.g., '2023-09-01').")
 	getCmd.Flags().String("end", "", "[REQUIRED] End date in RFC3339 format (e.g., '2023-09-30T23:59:59.999Z') or 'yyyy-MM-dd' format (e.g., '2023-09-30').")
-	getCmd.Flags().StringArray("cluster-name", []string{}, "[REQUIRED] Cluster names. Multiple names can be specified by using multiple --cluster-name arguments.")
-	getCmd.Flags().String("output-format", "csv", "[OPTIONAL] Output format. Possible values: csv, json.")
+	getCmd.Flags().StringArray("cluster-name", []string{}, "[OPTIONAL] Cluster names. Multiple names can be specified by using multiple --cluster-name arguments.")
+	getCmd.Flags().String("output-format", "", "[OPTIONAL] Output format. Possible values: csv, json.")
 	getCmd.Flags().String("output-file", "", "[OPTIONAL] Output filename.")
+	getCmd.Flags().BoolP("force", "f", false, "[OPTIONAL] Overwrite the output file if it exists")
 }

--- a/cmd/usage_test.go
+++ b/cmd/usage_test.go
@@ -1,0 +1,246 @@
+package cmd_test
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gexec"
+	"github.com/onsi/gomega/ghttp"
+	openapi "github.com/yugabyte/yugabytedb-managed-go-client-internal"
+)
+
+var _ = Describe("Spend Tracking", func() {
+
+	var (
+		server                *ghttp.Server
+		statusCode            int
+		args                  []string
+		responseAccount       openapi.AccountListResponse
+		responseProject       openapi.AccountListResponse
+		responseListClusters  openapi.ListClustersByDateRangeResponse
+		responseSpendTracking openapi.BillingUsageResponse
+	)
+
+	BeforeEach(func() {
+		args = os.Args
+		os.Args = []string{}
+		var err error
+		server, err = newGhttpServer(responseAccount, responseProject)
+		Expect(err).ToNot(HaveOccurred())
+		os.Setenv("YBM_HOST", fmt.Sprintf("http://%s", server.Addr()))
+		os.Setenv("YBM_APIKEY", "test-token")
+
+		statusCode = 200
+		err = loadJson("./test/fixtures/list-clusters-date-range.json", &responseListClusters)
+		Expect(err).ToNot(HaveOccurred())
+		err = loadJson("./test/fixtures/usage-data.json", &responseSpendTracking)
+		Expect(err).ToNot(HaveOccurred())
+		server.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/billing-usage/clusters"),
+				ghttp.RespondWithJSONEncodedPtr(&statusCode, responseListClusters),
+			),
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/billing-usage"),
+				ghttp.RespondWithJSONEncodedPtr(&statusCode, responseSpendTracking),
+			),
+		)
+	})
+
+	Context("Validating output", func() {
+		It("should return json file in output", func() {
+			cmd := exec.Command(compiledCLIPath, "usage", "get", "--start", "2022-10-12T15:30:00Z", "--end", "2022-10-15T15:30:00Z", "--output-file", "usage", "--output-format", "json")
+			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+			session.Wait(2)
+
+			usageContents, err := os.ReadFile("usage.json")
+			Expect(err).ToNot(HaveOccurred())
+
+			expectedContents, err := os.ReadFile("./test/fixtures/usage-data.json")
+			Expect(err).ToNot(HaveOccurred())
+
+			// Unmarshal the JSON data into a map for both actual and expected
+			var actualData map[string]interface{}
+			var expectedData map[string]interface{}
+			err = json.Unmarshal(usageContents, &actualData)
+			Expect(err).ToNot(HaveOccurred())
+			err = json.Unmarshal(expectedContents, &expectedData)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(actualData).To(Equal(expectedData))
+			Expect(session.Out).Should(gbytes.Say("JSON data written to usage.json\n"))
+			os.Remove("usage.json")
+			session.Kill()
+		})
+
+		It("should return csv file in output", func() {
+			cmd := exec.Command(compiledCLIPath, "usage", "get", "--start", "2022-10-12T15:30:00Z", "--end", "2022-10-15T15:30:00Z", "--output-file", "usage", "--output-format", "csv")
+			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+			session.Wait(2)
+
+			usageContents, err := os.ReadFile("usage.csv")
+			Expect(err).ToNot(HaveOccurred())
+
+			reader := csv.NewReader(strings.NewReader(string(usageContents)))
+
+			records, err := reader.ReadAll()
+			Expect(err).ToNot(HaveOccurred())
+
+			// Join all rows from the csv
+			actual := ""
+			for _, row := range records {
+				actual += strings.Join(row, ",") + "\n"
+			}
+
+			expected := "Date,Clusters,VCPUS_Daily,VCPUS_Cumulative,DISK_STORAGE_Daily,DISK_STORAGE_Cumulative,DISK_IOPS_Daily,DISK_IOPS_Cumulative,BACKUP_STORAGE_Daily,BACKUP_STORAGE_Cumulative,DATA_TRANSFER_WITHIN_REGION_Daily,DATA_TRANSFER_WITHIN_REGION_Cumulative,DATA_TRANSFER_CROSS_REGION_APAC_Daily,DATA_TRANSFER_CROSS_REGION_APAC_Cumulative,DATA_TRANSFER_CROSS_REGION_NON_APAC_Daily,DATA_TRANSFER_CROSS_REGION_NON_APAC_Cumulative,DATA_TRANSFER_INTERNET_Daily,DATA_TRANSFER_INTERNET_Cumulative\n" +
+				"2023-08-13,'courageous-jellyfish','willing-walrus',120.520000,120.520000,6026.000000,6026.000000,0.000000,0.000000,0.000000,0.000000,1.962233,1.962233,0.000000,0.000000,0.173324,0.173324,0.118982,0.118982\n" +
+				"2023-08-14,'courageous-jellyfish','willing-walrus',0.000000,120.520000,0.000000,6026.000000,0.000000,0.000000,0.000000,0.000000,0.000000,1.962233,0.000000,0.000000,0.000000,0.173324,0.000023,0.119005\n" +
+				"2023-08-15,'courageous-jellyfish','willing-walrus',0.000000,120.520000,0.000000,6026.000000,0.000000,0.000000,0.000000,0.000000,0.000000,1.962233,0.000000,0.000000,0.000000,0.173324,0.000018,0.119023\n"
+
+			Expect(actual).To(Equal(expected))
+			Expect(session.Out).Should(gbytes.Say("CSV data written to usage.csv\n"))
+			os.Remove("usage.csv")
+			session.Kill()
+		})
+
+		It("should fail if the clusters is not present", func() {
+			clusterName := "charming-canid, passionate-manatee"
+			cmd := exec.Command(compiledCLIPath, "usage", "get", "--start", "2022-10-12T15:30:00Z", "--end", "2022-10-15T15:30:00Z", "--output-file", "usage", "--output-format", "csv", "--cluster-name", "charming-canid", "--cluster-name", "passionate-manatee")
+			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+			session.Wait(2)
+			Expect(session.Err).Should(gbytes.Say("clusters '%s' not found within the specified time range", clusterName))
+			session.Kill()
+		})
+	})
+
+	Context("Date related", func() {
+		It("should succeed if start date or end date is in yyyy-mm-dd format", func() {
+			cmd := exec.Command(compiledCLIPath, "usage", "get", "--start", "2022-10-18", "--end", "2023-10-15", "--output-file", "usage", "--output-format", "csv")
+			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+			session.Wait(2)
+			Expect(session.Out).Should(gbytes.Say("CSV data written to usage.csv\n"))
+			os.Remove("usage.csv")
+			session.Kill()
+		})
+		It("should fail if start date or end date not present", func() {
+			cmd := exec.Command(compiledCLIPath, "usage", "get", "--output-file", "usage", "--output-format", "csv")
+			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+			session.Wait(2)
+			Expect(session.Err).Should(gbytes.Say("both start date and end date are required"))
+			session.Kill()
+		})
+
+		It("should fail if start date is before end date", func() {
+			cmd := exec.Command(compiledCLIPath, "usage", "get", "--start", "2022-10-18T15:30:00Z", "--end", "2022-10-15T15:30:00Z", "--output-file", "usage", "--output-format", "csv")
+			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+			session.Wait(2)
+			Expect(session.Err).Should(gbytes.Say("start date must be before end date"))
+			session.Kill()
+		})
+
+		It("should fail if the start date or end date is in invalid format", func() {
+			cmd := exec.Command(compiledCLIPath, "usage", "get", "--start", "18-02-2022", "--end", "2022-10-19T15:30:00Z", "--output-file", "usage", "--output-format", "csv")
+			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+			session.Wait(2)
+			Expect(session.Err).Should(gbytes.Say("invalid start date format"))
+			session.Kill()
+		})
+	})
+
+	Context("Filename related", func() {
+		It("should succeed if file name and format not specified", func() {
+			cmd := exec.Command(compiledCLIPath, "usage", "get", "--start", "2022-10-12T15:30:00Z", "--end", "2022-10-15T15:30:00Z")
+			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+			session.Wait(2)
+			// It should take default fileame and format
+			expectedFileName := "usage_20221012T153000_20221015T153000.csv"
+			_, err = os.Stat(expectedFileName)
+			Expect(err).NotTo(HaveOccurred())
+			os.Remove(expectedFileName)
+			session.Kill()
+		})
+
+		It("should fail if the file extension is invalid", func() {
+			cmd := exec.Command(compiledCLIPath, "usage", "get", "--start", "2022-10-12T15:30:00Z", "--end", "2022-10-15T15:30:00Z", "--output-file", "usage", "--output-format", "abc")
+			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+			session.Wait(2)
+			Expect(session.Err).Should(gbytes.Say("file extension abc is not supported"))
+			session.Kill()
+		})
+
+		It("should succeed if file already exists but force flag is present", func() {
+			fileName := "usage.json"
+			err := os.WriteFile(fileName, []byte("dummy content"), 0644)
+			Expect(err).NotTo(HaveOccurred())
+			cmd := exec.Command(compiledCLIPath, "usage", "get", "--start", "2022-10-12T15:30:00Z", "--end", "2022-10-15T15:30:00Z", "--output-file", fileName, "--output-format", "json", "--force")
+			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+			session.Wait(2)
+
+			usageContents, err := os.ReadFile("usage.json")
+			Expect(err).ToNot(HaveOccurred())
+
+			expectedContents, err := os.ReadFile("./test/fixtures/usage-data.json")
+			Expect(err).ToNot(HaveOccurred())
+
+			var actualData map[string]interface{}
+			var expectedData map[string]interface{}
+			err = json.Unmarshal(usageContents, &actualData)
+			Expect(err).ToNot(HaveOccurred())
+			err = json.Unmarshal(expectedContents, &expectedData)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(actualData).To(Equal(expectedData))
+			Expect(session.Out).Should(gbytes.Say("JSON data written to usage.json\n"))
+			os.Remove("usage.json")
+			session.Kill()
+		})
+
+		It("should fail if the filename already exists without force flag", func() {
+			dummyFilename := "usage.csv"
+			err := os.WriteFile(dummyFilename, []byte("dummy content"), 0644)
+			Expect(err).NotTo(HaveOccurred())
+
+			cmd := exec.Command(compiledCLIPath, "usage", "get", "--start", "2022-10-12T15:30:00Z", "--end", "2022-10-15T15:30:00Z", "--output-file", "usage", "--output-format", "csv")
+			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+			session.Wait(2)
+			Expect(session.Err).Should(gbytes.Say("file usage.csv already exists"))
+
+			os.Remove(dummyFilename)
+			session.Kill()
+		})
+
+		It("should succeed if the filename has a valid extension", func() {
+			cmd := exec.Command(compiledCLIPath, "usage", "get", "--start", "2022-10-12T15:30:00Z", "--end", "2022-10-15T15:30:00Z", "--output-file", "usage.json", "--output-format", "csv")
+			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+			session.Wait(2)
+			Expect(session.Out).Should(gbytes.Say("JSON data written to usage.json\n"))
+			os.Remove("usage.json")
+			session.Kill()
+		})
+	})
+
+	AfterEach(func() {
+		os.Args = args
+		server.Close()
+	})
+})

--- a/docs/ybm_usage_get.md
+++ b/docs/ybm_usage_get.md
@@ -13,8 +13,9 @@ ybm usage get [flags]
 ### Options
 
 ```
-      --cluster-name stringArray   [REQUIRED] Cluster names. Multiple names can be specified by using multiple --cluster-name arguments.
+      --cluster-name stringArray   [OPTIONAL] Cluster names. Multiple names can be specified by using multiple --cluster-name arguments.
       --end string                 [REQUIRED] End date in RFC3339 format (e.g., '2023-09-30T23:59:59.999Z') or 'yyyy-MM-dd' format (e.g., '2023-09-30').
+  -f, --force                      [OPTIONAL] Overwrite the output file if it exists
   -h, --help                       help for get
       --output-file string         [OPTIONAL] Output filename.
       --output-format string       [OPTIONAL] Output format. Possible values: csv, json. (default "csv")

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.15.0
 	github.com/t-tomalak/logrus-easy-formatter v0.0.0-20190827215021-c074f06c5816
-	github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20231005213122-c1389755cc7f
+	github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20231027150409-d16e4f5ea79a
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9
 	golang.org/x/mod v0.12.0
 	golang.org/x/term v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -282,6 +282,10 @@ github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20231002173116-
 github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20231002173116-4bef65a4f62e/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
 github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20231005213122-c1389755cc7f h1:6JM4ixKyL6NNjs1iib6HIdZmNNTL8e1SAqfGmhADQk4=
 github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20231005213122-c1389755cc7f/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20231026233429-119fac53404b h1:lCngnLCV8esz/HdwQ8N6r+VpRgc/Gk+WP4rv2KSsQVA=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20231026233429-119fac53404b/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20231027150409-d16e4f5ea79a h1:FvJRQ1i9qtO/tKVecEzHSYgFx/65A1aL/c5nst5/agA=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20231027150409-d16e4f5ea79a/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
Summary:
This PR contains the fix for the following :
1. OS did not show the filename extension along with the filename. 
2. CSV data was inconsistent with JSON

It also adds a --force flag which can overwrite the file if it already exists.
`
./ybm usage get --start 2022-10-12T15:30:00Z --end 2022-10-20T15:30:00Z --output-format csv --force
`
