### PR TITLE
[CLOUDGA-17496] Add support for Azure CMK 

### DIFF
--- a/cmd/cluster/create_cluster.go
+++ b/cmd/cluster/create_cluster.go
@@ -185,6 +185,8 @@ func init() {
 	aws-access-key can be ommitted if the environment variable YBM_AWS_SECRET_KEY is set. If the environment variable is not set, the user will be prompted to enter the value.
 	For GCP:
 	cloud-provider=GCP,gcp-resource-id=<resource-id>,gcp-service-account-path=<service-account-path>.
+	For AZURE:
+	cloud-provider=AZURE,azu-client-id=<client-id>,azu-client-secret=<client-secret>,azu-tenant-id=<tenant-id>,azu-key-name=<key-name>,azu-key-vault-uri=<key-vault-uri>.
 	If specified, all parameters for that provider are mandatory.`)
 	createClusterCmd.Flags().String("fault-tolerance", "", "[OPTIONAL] The fault tolerance domain of the cluster. The possible values are NONE, NODE, ZONE and REGION. Default NONE.")
 	createClusterCmd.Flags().Int32("num-faults-to-tolerate", 0, "[OPTIONAL] The number of domain faults to tolerate for the level specified. The possible values are 0 for NONE, 1 for ZONE and [1-3] for anything else. Defaults to 0 for NONE, 1 otherwise.")

--- a/cmd/cluster/encryption/encryption.go
+++ b/cmd/cluster/encryption/encryption.go
@@ -154,7 +154,7 @@ var updateCmk = &cobra.Command{
 			logrus.Debugf("Full HTTP response: %v", res)
 			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
-		fmt.Printf("Successfully updated encryption spec for cluster %s\n", clusterName)
+		fmt.Printf("Successfully updated encryption spec for cluster %s\n", formatter.Colorize(clusterName, formatter.GREEN_COLOR))
 	},
 }
 
@@ -168,7 +168,10 @@ func init() {
 	cloud-provider=AWS,aws-secret-key=<secret-key>,aws-access-key=<access-key>,aws-arn=<arn1>,aws-arn=<arn2> .
 	aws-access-key can be ommitted if the environment variable YBM_AWS_SECRET_KEY is set. If the environment variable is not set, the user will be prompted to enter the value.
 	For GCP:
-	cloud-provider=GCP,gcp-resource-id=<resource-id>,gcp-service-account-path=<service-account-path>.`)
+	cloud-provider=GCP,gcp-resource-id=<resource-id>,gcp-service-account-path=<service-account-path>.
+	For AZURE:
+	cloud-provider=AZURE,azu-client-id=<client-id>,azu-client-secret=<client-secret>,azu-tenant-id=<tenant-id>,azu-key-name=<key-name>,azu-key-vault-uri=<key-vault-uri>.
+	`)
 	updateCmk.MarkFlagRequired("encryption-spec")
 	updateCmkState.Flags().Bool("enable", false, "Enable EAR")
 	updateCmkState.Flags().Bool("disable", false, "Disable EAR")

--- a/docs/ybm_cluster_create.md
+++ b/docs/ybm_cluster_create.md
@@ -26,6 +26,8 @@ ybm cluster create [flags]
                                        	aws-access-key can be ommitted if the environment variable YBM_AWS_SECRET_KEY is set. If the environment variable is not set, the user will be prompted to enter the value.
                                        	For GCP:
                                        	cloud-provider=GCP,gcp-resource-id=<resource-id>,gcp-service-account-path=<service-account-path>.
+                                       	For AZURE:
+                                       	cloud-provider=AZURE,azu-client-id=<client-id>,azu-client-secret=<client-secret>,azu-tenant-id=<tenant-id>,azu-key-name=<key-name>,azu-key-vault-uri=<key-vault-uri>.
                                        	If specified, all parameters for that provider are mandatory.
       --fault-tolerance string         [OPTIONAL] The fault tolerance domain of the cluster. The possible values are NONE, NODE, ZONE and REGION. Default NONE.
       --num-faults-to-tolerate int32   [OPTIONAL] The number of domain faults to tolerate for the level specified. The possible values are 0 for NONE, 1 for ZONE and [1-3] for anything else. Defaults to 0 for NONE, 1 otherwise.

--- a/docs/ybm_cluster_encryption_update.md
+++ b/docs/ybm_cluster_encryption_update.md
@@ -20,6 +20,9 @@ ybm cluster encryption update [flags]
                                  	aws-access-key can be ommitted if the environment variable YBM_AWS_SECRET_KEY is set. If the environment variable is not set, the user will be prompted to enter the value.
                                  	For GCP:
                                  	cloud-provider=GCP,gcp-resource-id=<resource-id>,gcp-service-account-path=<service-account-path>.
+                                 	For AZURE:
+                                 	cloud-provider=AZURE,azu-client-id=<client-id>,azu-client-secret=<client-secret>,azu-tenant-id=<tenant-id>,azu-key-name=<key-name>,azu-key-vault-uri=<key-vault-uri>.
+                                 	
   -h, --help                     help for update
 ```
 

--- a/docs/ybm_usage_get.md
+++ b/docs/ybm_usage_get.md
@@ -18,7 +18,7 @@ ybm usage get [flags]
   -f, --force                      [OPTIONAL] Overwrite the output file if it exists
   -h, --help                       help for get
       --output-file string         [OPTIONAL] Output filename.
-      --output-format string       [OPTIONAL] Output format. Possible values: csv, json. (default "csv")
+      --output-format string       [OPTIONAL] Output format. Possible values: csv, json.
       --start string               [REQUIRED] Start date in RFC3339 format (e.g., '2023-09-01T12:30:45.000Z') or 'yyyy-MM-dd' format (e.g., '2023-09-01').
 ```
 

--- a/internal/formatter/encryption.go
+++ b/internal/formatter/encryption.go
@@ -79,6 +79,8 @@ func (c *CMKContext) CMKStatus() ybmclient.CMKStatusEnum {
 func (c *CMKContext) KeyAlias() string {
 	if c.c.GcpCmkSpec.Get().GetKeyName() != "" {
 		return c.c.GcpCmkSpec.Get().GetKeyName()
+	} else if c.c.AzureCmkSpec.Get().GetKeyName() != "" {
+		return c.c.AzureCmkSpec.Get().GetKeyName()
 	}
 	return c.c.AwsCmkSpec.Get().GetAliasName()
 }
@@ -96,6 +98,8 @@ func (c *CMKContext) ResourceId() string {
 func (c *CMKContext) SecurityPrincipals() string {
 	if c.c.GcpCmkSpec.Get().GetKeyName() != "" {
 		return c.ResourceId()
+	} else if c.c.AzureCmkSpec.Get().GetKeyName() != "" {
+		return c.c.AzureCmkSpec.Get().GetKeyVaultUri()
 	}
 	return strings.Join(c.c.AwsCmkSpec.Get().GetArnList(), ", ")
 }


### PR DESCRIPTION
Summary:

Add support for the following operations for Azure CMK.

###  Create cluster with azure cmk
`ybm cluster create --encryption-spec provider=AZURE,azu-client-id=<client-id>,azu-client-secret=<client-secret>,azu-tenant-id=<tenant-id>,azu-key-name=<key-name>,azu-key-vault-uri=<key-vault-uri>
`

### Describe cluster 
`ybm cluster describe --cluster-name test-cluster-azure`

### Update cmk
`ybm cluster encryption update --encryption-spec provider=AZURE,azu-client-id=<client-id>,azu-client-secret=<client-secret>,azu-tenant-id=<tenant-id>,azu-key-name=<key-name>,azu-key-vault-uri=<key-vault-uri>`

### Update cmk state

`ybm cluster encryption update-state --cluster-name test-cluster-arishta --enable`
