### PR TITLE
Display retention period for backup policies

### DIFF
--- a/cmd/backup_shedule_test.go
+++ b/cmd/backup_shedule_test.go
@@ -84,8 +84,8 @@ var _ = Describe("BackupSchedules", func() {
 				Expect(err).NotTo(HaveOccurred())
 				session.Wait(2)
 				o := string(session.Out.Contents()[:])
-				expected := `Time Interval(days)   Days of the Week   Backup Start Time
-1                     NA                 NA` + "\n"
+				expected := `Time Interval(days)   Days of the Week   Backup Start Time   Retention Period(days)
+1                     NA                 NA                  8` + "\n"
 				Expect(o).Should(Equal(expected))
 
 				session.Kill()
@@ -122,9 +122,11 @@ var _ = Describe("BackupSchedules", func() {
 				o := string(session.Out.Contents()[:])
 
 				// no backup schedule must be returned if it is paused
-				expected := `Time Interval(days)   Days of the Week   Backup Start Time
-NA                    Su,We,Fr           ` + getLocalTime("2 3 * * *") + "\n"
+				fmt.Println(o)
+				expected := `Time Interval(days)   Days of the Week   Backup Start Time   Retention Period(days)
+NA                    Su,We,Fr           ` + getLocalTime("2 3 * * *") + `               8` + "\n"
 				Expect(o).Should(Equal(expected))
+				fmt.Println(expected)
 
 				session.Kill()
 			})

--- a/internal/formatter/backup_policy_list.go
+++ b/internal/formatter/backup_policy_list.go
@@ -27,10 +27,11 @@ import (
 )
 
 const (
-	defaultBackupPolicyListing = "table {{.TimeInterval}}\t{{.DaysOfTheWeek}}\t{{.BackupStartTime}}"
+	defaultBackupPolicyListing = "table {{.TimeInterval}}\t{{.DaysOfTheWeek}}\t{{.BackupStartTime}}\t{{.RetentionPeriod}}"
 	timeIntervalHeader         = "Time Interval(days)"
 	daysOfTheWeekHeader        = "Days of the Week"
 	backupStartTimeHeader      = "Backup Start Time"
+	retentionPeriodInDays      = "Retention Period(days)"
 )
 
 type BackupPolicyContext struct {
@@ -71,16 +72,23 @@ func NewBackupPolicyContext() *BackupPolicyContext {
 		"TimeInterval":    timeIntervalHeader,
 		"DaysOfTheWeek":   daysOfTheWeekHeader,
 		"BackupStartTime": backupStartTimeHeader,
+		"RetentionPeriod": retentionPeriodInDays,
 	}
 	return &backupPolicyCtx
 }
 
 func (c *BackupPolicyContext) TimeInterval() string {
 	timeInterval := c.c.Spec.GetTimeIntervalInDays()
+
 	if timeInterval != 0 {
 		return fmt.Sprintf("%d", timeInterval)
 	}
 	return "NA"
+}
+
+func (c *BackupPolicyContext) RetentionPeriod() string {
+	retentionPeriodInDays := int32(c.c.Info.GetTaskParams()["retention_period_in_days"].(float64))
+	return fmt.Sprintf("%d", retentionPeriodInDays)
 }
 
 func (c *BackupPolicyContext) DaysOfTheWeek() string {


### PR DESCRIPTION
The retention period will now be displayed as follows:
```
bash-5.2$ ./ybm backup policy list --cluster-name=loyal-mackerel
Time Interval(days)   Days of the Week   Backup Start Time   Retention Period(days)
1                     NA                 NA                  8
```