### PR TITLE
[CLOUDGA-18071] CLI support for asymmetric geo-partitioned cluster creation

### DIFF
--- a/cmd/util/feature_flags.go
+++ b/cmd/util/feature_flags.go
@@ -32,6 +32,7 @@ const (
 	AZURE_CIDR_ALLOWED  FeatureFlag = "AZURE_CIDR_ALLOWED"
 	ENTERPRISE_SECURITY FeatureFlag = "ENTERPRISE_SECURITY"
 	INCREMENTAL_BACKUP  FeatureFlag = "INCREMENTAL_BACKUP"
+	ASYMMETRIC_GEO      FeatureFlag = "ASYMMETRIC_GEO"
 )
 
 func (f FeatureFlag) String() string {

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.17.0
 	github.com/t-tomalak/logrus-easy-formatter v0.0.0-20190827215021-c074f06c5816
-	github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20240123191212-6c0c5862cc02
+	github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20240131113907-1ba9d5e67a7a
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9
 	golang.org/x/mod v0.14.0
 	golang.org/x/term v0.15.0

--- a/go.sum
+++ b/go.sum
@@ -282,8 +282,8 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/t-tomalak/logrus-easy-formatter v0.0.0-20190827215021-c074f06c5816 h1:J6v8awz+me+xeb/cUTotKgceAYouhIB3pjzgRd6IlGk=
 github.com/t-tomalak/logrus-easy-formatter v0.0.0-20190827215021-c074f06c5816/go.mod h1:tzym/CEb5jnFI+Q0k4Qq3+LvRF4gO3E2pxS8fHP8jcA=
-github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20240123191212-6c0c5862cc02 h1:nE2LaAIy3Tsv9QRVqxwShsqQ2rIkXMGU8tsUHf52fAY=
-github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20240123191212-6c0c5862cc02/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20240131113907-1ba9d5e67a7a h1:Lj0hIO1LuXJ4jO0dEe8dIBX9X06CSvo6xNfdV8spJKs=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20240131113907-1ba9d5e67a7a/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/internal/formatter/clusters_full.go
+++ b/internal/formatter/clusters_full.go
@@ -297,15 +297,33 @@ func (c *clusterInfoRegionsContext) NumNode() string {
 }
 
 func (c *clusterInfoRegionsContext) NumCores() string {
-	return fmt.Sprintf("%d", c.clusterInfo.NodeInfo.NumCores)
+    numCores := c.clusterInfo.NodeInfo.NumCores
+    if c.clusterInfoRegion.NodeInfo.IsSet() {
+        if nc, ok := c.clusterInfoRegion.NodeInfo.Get().GetNumCoresOk(); ok {
+            numCores = *nc
+        }
+    }
+	return fmt.Sprintf("%d", numCores)
 }
 
 func (c *clusterInfoRegionsContext) MemoryGb() string {
-	return convertMbtoGb(c.clusterInfo.NodeInfo.MemoryMb)
+    memoryMb := c.clusterInfo.NodeInfo.MemoryMb
+    if c.clusterInfoRegion.NodeInfo.IsSet() {
+        if mem, ok := c.clusterInfoRegion.NodeInfo.Get().GetMemoryMbOk(); ok {
+            memoryMb = *mem
+        }
+    }
+	return convertMbtoGb(memoryMb)
 }
 
 func (c *clusterInfoRegionsContext) DiskSizeGb() string {
-	return fmt.Sprintf("%dGB", c.clusterInfo.NodeInfo.DiskSizeGb)
+    diskSizeGb := c.clusterInfo.NodeInfo.DiskSizeGb
+    if c.clusterInfoRegion.NodeInfo.IsSet() {
+        if ds, ok := c.clusterInfoRegion.NodeInfo.Get().GetDiskSizeGbOk(); ok {
+            diskSizeGb = *ds
+        }
+    }
+	return fmt.Sprintf("%dGB", diskSizeGb)
 }
 
 func (c *clusterInfoRegionsContext) Region() string {

--- a/internal/formatter/instance_types.go
+++ b/internal/formatter/instance_types.go
@@ -23,12 +23,12 @@ import (
 )
 
 const (
-	defaulInstanceTypeListing = "table {{.Cores}}\t{{.Memory}}\t{{.DiskSize}}\t{{.AZs}}\t{{.IsEnabled}}"
-	coresHeader               = "Number of Cores"
-	memoryHeader              = "Memory (MB)"
-	diskSizeHeader            = "Disk Size (GB)"
-	azsHeader                 = "Number of Availability Zones"
-	isEnabledHeader           = "Is Enabled"
+	defaultInstanceTypeListing = "table {{.Cores}}\t{{.Memory}}\t{{.DiskSize}}\t{{.AZs}}\t{{.IsEnabled}}"
+	coresHeader                = "Number of Cores"
+	memoryHeader               = "Memory (MB)"
+	diskSizeHeader             = "Disk Size (GB)"
+	azsHeader                  = "Number of Availability Zones"
+	isEnabledHeader            = "Is Enabled"
 )
 
 type InstanceTypeContext struct {
@@ -40,7 +40,7 @@ type InstanceTypeContext struct {
 func NewInstanceTypeFormat(source string) Format {
 	switch source {
 	case "table", "":
-		format := defaulInstanceTypeListing
+		format := defaultInstanceTypeListing
 		return Format(format)
 	default: // custom format or json or pretty
 		return Format(source)


### PR DESCRIPTION
### Summary
- Added support for asymmetric geo-partitioned cluster creation (different regions can now have different num-cores, disk-size-gb, disk-iops for different regions - only for geo-partitioned clusters)
- New flows are hidden behind the ASYMMETRIC_GEO feature flag

### Testing
- Successfully created, updated, and described asymmetric geo cluster
- Correctly fails when attempting to create asymmetric synchronous cluster

The new payloads look like:

```
./ybm cluster create --cluster-name asymmetric-geo-cli-2 --credentials username=vm,password=pwd --cloud-provider AWS --cluster-tier Dedicated --fault-tolerance REGION --region-info region=us-west-2,num-nodes=1,vpc=aws-west-2,num-cores=2 --region-info region=us-east-2,num-nodes=1,vpc=aws-east-2,num-cores=4 --region-info region=ca-central-1,num-nodes=1,vpc=aws-central-1,num-cores=8,disk-size-gb=500,disk-iops=4000 --cluster-type GEO_PARTITIONED
```

```
./ybm cluster update --cluster-name asymmetric-geo-cli-1 --region-info region=us-west-2,num-nodes=2,vpc=aws-west-2,num-cores=4,disk-iops=4000 --region-info region=us-east-2,num-nodes=2,vpc=aws-east-2,num-cores=4,disk-size-gb=700 --region-info region=ca-central-1,num-nodes=2,vpc=aws-central-1,num-cores=8,disk-size-gb=600,disk-iops=3000

```