### PR TITLE
[CLOUDGA-19819] Set correct memory size in edit flow

### DIFF
--- a/cmd/cluster/update_cluster.go
+++ b/cmd/cluster/update_cluster.go
@@ -65,27 +65,27 @@ var updateClusterCmd = &cobra.Command{
 
 		regionInfoMapList := []map[string]string{}
 		changedRegionInfo := cmd.Flags().Changed("region-info")
-        changedNodeInfo := cmd.Flags().Changed("node-config")
+		changedNodeInfo := cmd.Flags().Changed("node-config")
 
-        defaultNumCores := 0
-        defaultDiskSizeGb := 0
-        defaultDiskIops := 0
-        if changedNodeInfo {
-            nodeConfig, _ := cmd.Flags().GetStringToInt("node-config")
-            numCores, ok := nodeConfig["num-cores"]
-            if !asymmetricGeoEnabled && !ok {
-                logrus.Fatalln("Number of cores not specified in node config")
-            }
-            if asymmetricGeoEnabled && ok {
-                defaultNumCores = numCores
-            }
-            if diskSizeGb, ok := nodeConfig["disk-size-gb"]; ok {
-                defaultDiskSizeGb = diskSizeGb
-            }
-            if diskIops, ok := nodeConfig["disk-iops"]; ok {
-                defaultDiskIops = diskIops
-            }
-        }
+		defaultNumCores := 0
+		defaultDiskSizeGb := 0
+		defaultDiskIops := 0
+		if changedNodeInfo {
+			nodeConfig, _ := cmd.Flags().GetStringToInt("node-config")
+			numCores, ok := nodeConfig["num-cores"]
+			if !asymmetricGeoEnabled && !ok {
+				logrus.Fatalln("Number of cores not specified in node config")
+			}
+			if asymmetricGeoEnabled && ok {
+				defaultNumCores = numCores
+			}
+			if diskSizeGb, ok := nodeConfig["disk-size-gb"]; ok {
+				defaultDiskSizeGb = diskSizeGb
+			}
+			if diskIops, ok := nodeConfig["disk-iops"]; ok {
+				defaultDiskIops = diskIops
+			}
+		}
 
 		if changedRegionInfo {
 			regionInfoList, _ := cmd.Flags().GetStringArray("region-info")
@@ -133,20 +133,20 @@ var updateClusterCmd = &cobra.Command{
 					logrus.Fatalln("Number of nodes not specified in region info")
 				}
 				if _, ok := regionInfoMap["num-cores"]; asymmetricGeoEnabled && !ok && defaultNumCores > 0 {
-                    regionInfoMap["num-cores"] = strconv.Itoa(defaultNumCores)
-                }
-                if _, ok := regionInfoMap["disk-size-gb"]; asymmetricGeoEnabled && !ok && defaultDiskSizeGb > 0 {
-                    regionInfoMap["disk-size-gb"] = strconv.Itoa(defaultDiskSizeGb)
-                }
-                if _, ok := regionInfoMap["disk-iops"]; asymmetricGeoEnabled && !ok && defaultDiskIops > 0 {
-                    regionInfoMap["disk-iops"] = strconv.Itoa(defaultDiskIops)
-                }
+					regionInfoMap["num-cores"] = strconv.Itoa(defaultNumCores)
+				}
+				if _, ok := regionInfoMap["disk-size-gb"]; asymmetricGeoEnabled && !ok && defaultDiskSizeGb > 0 {
+					regionInfoMap["disk-size-gb"] = strconv.Itoa(defaultDiskSizeGb)
+				}
+				if _, ok := regionInfoMap["disk-iops"]; asymmetricGeoEnabled && !ok && defaultDiskIops > 0 {
+					regionInfoMap["disk-iops"] = strconv.Itoa(defaultDiskIops)
+				}
 
 				regionInfoMapList = append(regionInfoMapList, regionInfoMap)
 			}
 		}
 
-		clusterSpec, err := authApi.CreateClusterSpec(cmd, regionInfoMapList)
+		clusterSpec, err := authApi.EditClusterSpec(cmd, regionInfoMapList, clusterID)
 		if err != nil {
 			logrus.Fatalf("Error while creating cluster spec: %v", err)
 		}


### PR DESCRIPTION
In an edit case, we should be using a different API to get the available node configurations to use. This PR does that and resolves https://yugabyte.atlassian.net/browse/CLOUDGA-19819.

**Test Plan**
```
daniel@da-mbp-y7d9w ybm-cli (CLOUDGA-19819) $ git checkout main
Switched to branch 'main'
Your branch is up to date with 'origin/main'.
daniel@da-mbp-y7d9w ybm-cli (main) $ make build
go build -ldflags="-X 'main.version=v0.1.0'" -o ybm
daniel@da-mbp-y7d9w ybm-cli (main) $ ./ybm cluster update --cluster-name rpendse-test-need-prod-global --region-info region=asia-northeast1,num-nodes=3,vpc=need-regions,num-cores=4,disk-size-gb=100 --region-info region=asia-east1,num-nodes=3,vpc=need-regions,num-cores=2,disk-size-gb=100 --region-info region=asia-northeast3,num-nodes=3,vpc=need-regions,num-cores=2,disk-size-gb=100 --region-info region=asia-southeast1,num-nodes=3,vpc=need-regions,num-cores=2,disk-size-gb=100 --region-info region=europe-west4,num-nodes=3,vpc=need-regions,num-cores=2,disk-size-gb=100 --region-info region=northamerica-northeast2,num-nodes=3,vpc=need-regions,num-cores=2,disk-size-gb=100 --region-info region=us-west2,num-nodes=3,vpc=need-regions,num-cores=2,disk-size-gb=100 --region-info region=australia-southeast2,num-nodes=3,vpc=need-regions,num-cores=2,disk-size-gb=100
A newer version is available. Please upgrade to the latest version v0.1.18
No compatible instance type found for the given cloud: GCP, region: asia-east1, cores: 2, memory: 8192
daniel@da-mbp-y7d9w ybm-cli (main) $ 
daniel@da-mbp-y7d9w ybm-cli (main) $ 
daniel@da-mbp-y7d9w ybm-cli (main) $ git checkout @{-1}
Switched to branch 'CLOUDGA-19819'
Your branch is up to date with 'origin/CLOUDGA-19819'.
daniel@da-mbp-y7d9w ybm-cli (CLOUDGA-19819) $ make build
go build -ldflags="-X 'main.version=v0.1.0'" -o ybm
daniel@da-mbp-y7d9w ybm-cli (CLOUDGA-19819) $ ./ybm cluster update --cluster-name rpendse-test-need-prod-global --region-info region=asia-northeast1,num-nodes=3,vpc=need-regions,num-cores=4,disk-size-gb=100 --region-info region=asia-east1,num-nodes=3,vpc=need-regions,num-cores=2,disk-size-gb=100 --region-info region=asia-northeast3,num-nodes=3,vpc=need-regions,num-cores=2,disk-size-gb=100 --region-info region=asia-southeast1,num-nodes=3,vpc=need-regions,num-cores=2,disk-size-gb=100 --region-info region=europe-west4,num-nodes=3,vpc=need-regions,num-cores=2,disk-size-gb=100 --region-info region=northamerica-northeast2,num-nodes=3,vpc=need-regions,num-cores=2,disk-size-gb=100 --region-info region=us-west2,num-nodes=3,vpc=need-regions,num-cores=2,disk-size-gb=100 --region-info region=australia-southeast2,num-nodes=3,vpc=need-regions,num-cores=2,disk-size-gb=100
A newer version is available. Please upgrade to the latest version v0.1.18
The cluster rpendse-test-need-prod-global is being updated
Name                            Tier        Version         State     Health    Provider   Regions         Nodes     Node Res.(Vcpu/Mem/DiskGB/IOPS)
rpendse-test-need-prod-global   Dedicated   2.14.15.0-b57   QUEUED    💚        GCP        asia-east1,+7   24        2 / 8GB / 100GB / -
```