### PR TITLE
[CLOUDGA-20741] Add support for cluster-name in DB audit

### DIFF
--- a/cmd/db_audit_logs_exporter/db_audit_logs_exporter.go
+++ b/cmd/db_audit_logs_exporter/db_audit_logs_exporter.go
@@ -52,10 +52,15 @@ var assignDbAuditLogsExporterCmd = &cobra.Command{
 		}
 		authApi.GetInfo("", "")
 
-		clusterId, _ := cmd.Flags().GetString("cluster-id")
+		clusterName, _ := cmd.Flags().GetString("cluster-name")
 		integrationName, _ := cmd.Flags().GetString("integration-name")
 		ysqlConfig, _ := cmd.Flags().GetStringToString("ysql-config")
 		statement_classes, _ := cmd.Flags().GetString("statement_classes")
+
+		clusterId, err := authApi.GetClusterIdByName(clusterName)
+		if err != nil {
+			logrus.Fatal(err)
+		}
 
 		integrationId, err := getIntegrationIdFromName(integrationName, authApi)
 
@@ -102,11 +107,16 @@ var updateDbAuditLogsExporterCmd = &cobra.Command{
 		}
 		authApi.GetInfo("", "")
 
-		clusterId, _ := cmd.Flags().GetString("cluster-id")
+		clusterName, _ := cmd.Flags().GetString("cluster-name")
 		exportConfigId, _ := cmd.Flags().GetString("export-config-id")
 		integrationName, _ := cmd.Flags().GetString("integration-name")
 		ysqlConfig, _ := cmd.Flags().GetStringToString("ysql-config")
 		statement_classes, _ := cmd.Flags().GetString("statement_classes")
+
+		clusterId, err := authApi.GetClusterIdByName(clusterName)
+		if err != nil {
+			logrus.Fatal(err)
+		}
 
 		integrationId, err := getIntegrationIdFromName(integrationName, authApi)
 
@@ -153,7 +163,12 @@ var listDbAuditLogsExporterCmd = &cobra.Command{
 		}
 		authApi.GetInfo("", "")
 
-		clusterId, _ := cmd.Flags().GetString("cluster-id")
+		clusterName, _ := cmd.Flags().GetString("cluster-name")
+
+		clusterId, err := authApi.GetClusterIdByName(clusterName)
+		if err != nil {
+			logrus.Fatal(err)
+		}
 
 		resp, r, err := authApi.ListDbAuditExporterConfig(clusterId).Execute()
 
@@ -195,8 +210,13 @@ var removeDbAuditLogsExporterCmd = &cobra.Command{
 		}
 		authApi.GetInfo("", "")
 
-		clusterId, _ := cmd.Flags().GetString("cluster-id")
+		clusterName, _ := cmd.Flags().GetString("cluster-name")
 		exportConfigId, _ := cmd.Flags().GetString("export-config-id")
+
+		clusterId, err := authApi.GetClusterIdByName(clusterName)
+		if err != nil {
+			logrus.Fatal(err)
+		}
 
 		resp, _, err := authApi.UnassignDbAuditLogsExportConfig(clusterId, exportConfigId).Execute()
 
@@ -222,13 +242,13 @@ func init() {
 	Please provide key value pairs as follows:
 	statement_classes=READ,WRITE,MISC`)
 	assignDbAuditLogsExporterCmd.MarkFlagRequired("statement_classes")
-	assignDbAuditLogsExporterCmd.Flags().String("cluster-id", "", "[REQUIRED] The cluster ID to assign DB auditting")
-	assignDbAuditLogsExporterCmd.MarkFlagRequired("cluster-id")
+	assignDbAuditLogsExporterCmd.Flags().String("cluster-name", "", "[REQUIRED] The cluster name to assign DB auditting")
+	assignDbAuditLogsExporterCmd.MarkFlagRequired("cluster-name")
 
 	DbAuditLogsExporterCmd.AddCommand(listDbAuditLogsExporterCmd)
 	listDbAuditLogsExporterCmd.Flags().SortFlags = false
-	listDbAuditLogsExporterCmd.Flags().String("cluster-id", "", "[REQUIRED] The cluster ID to list DB audit export config")
-	listDbAuditLogsExporterCmd.MarkFlagRequired("cluster-id")
+	listDbAuditLogsExporterCmd.Flags().String("cluster-name", "", "[REQUIRED] The cluster name to list DB audit export config")
+	listDbAuditLogsExporterCmd.MarkFlagRequired("cluster-name")
 
 	DbAuditLogsExporterCmd.AddCommand(updateDbAuditLogsExporterCmd)
 	updateDbAuditLogsExporterCmd.Flags().SortFlags = false
@@ -243,15 +263,15 @@ func init() {
 	updateDbAuditLogsExporterCmd.Flags().String("statement_classes", "", `The ysql config statement classes
 	Please provide key value pairs as follows:
 	statement_classes=READ,WRITE,MISC`)
-	updateDbAuditLogsExporterCmd.Flags().String("cluster-id", "", "[REQUIRED] The cluster ID to assign DB auditting")
-	updateDbAuditLogsExporterCmd.MarkFlagRequired("cluster-id")
+	updateDbAuditLogsExporterCmd.Flags().String("cluster-name", "", "[REQUIRED] The cluster name to assign DB auditting")
+	updateDbAuditLogsExporterCmd.MarkFlagRequired("cluster-name")
 
 	DbAuditLogsExporterCmd.AddCommand(removeDbAuditLogsExporterCmd)
 	removeDbAuditLogsExporterCmd.Flags().SortFlags = false
 	removeDbAuditLogsExporterCmd.Flags().String("export-config-id", "", "[REQUIRED] The ID of the DB audit export config")
 	removeDbAuditLogsExporterCmd.MarkFlagRequired("export-config-id")
-	removeDbAuditLogsExporterCmd.Flags().String("cluster-id", "", "[REQUIRED] The cluster ID to assign DB auditting")
-	removeDbAuditLogsExporterCmd.MarkFlagRequired("cluster-id")
+	removeDbAuditLogsExporterCmd.Flags().String("cluster-name", "", "[REQUIRED] The cluster name to assign DB auditting")
+	removeDbAuditLogsExporterCmd.MarkFlagRequired("cluster-name")
 	removeDbAuditLogsExporterCmd.Flags().BoolP("force", "f", false, "Bypass the prompt for non-interactive usage")
 }
 

--- a/cmd/db_audit_logs_exporter_test.go
+++ b/cmd/db_audit_logs_exporter_test.go
@@ -40,6 +40,7 @@ var _ = Describe("Db Audit", func() {
 		responseDbAudit     	openapi.DbAuditExporterConfigResponse
 		responseDbAuditList 	openapi.DbAuditExporterConfigListResponse
 		responseIntegrationList openapi.TelemetryProviderListResponse
+		responseListClusters    openapi.ClusterListResponse
 	)
 
 	BeforeEach(func() {
@@ -51,6 +52,15 @@ var _ = Describe("Db Audit", func() {
 		os.Setenv("YBM_HOST", fmt.Sprintf("http://%s", server.Addr()))
 		os.Setenv("YBM_APIKEY", "test-token")
 		os.Setenv("YBM_FF_DB_AUDIT_LOGS", "true")
+		statusCode = 200
+		err = loadJson("./test/fixtures/list-clusters.json", &responseListClusters)
+		Expect(err).ToNot(HaveOccurred())
+		server.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/clusters"),
+				ghttp.RespondWithJSONEncodedPtr(&statusCode, responseListClusters),
+			),
+		)
 	})
 
 	Context("When associating DB Audit config", func() {
@@ -68,17 +78,17 @@ var _ = Describe("Db Audit", func() {
 			Expect(err).ToNot(HaveOccurred())
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
-					ghttp.VerifyRequest(http.MethodPost, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/clusters/7bb68af6-0875-42e0-8665-dcf634ed9fd1/db-audit-log-exporter-configs"),
+					ghttp.VerifyRequest(http.MethodPost, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/clusters/5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8/db-audit-log-exporter-configs"),
 					ghttp.RespondWithJSONEncodedPtr(&statusCode, responseDbAudit),
 				),
 			)
-			cmd := exec.Command(compiledCLIPath, "db-audit-logs-exporter", "assign", "--cluster-id", "7bb68af6-0875-42e0-8665-dcf634ed9fd1", "--integration-name", "datadog-tp", "--ysql-config", "log_catalog=true,log_client=true,log_level=NOTICE,log_parameter=false,log_statement_once=false,log_relation=false", "--statement_classes", "READ,WRITE")
+			cmd := exec.Command(compiledCLIPath, "db-audit-logs-exporter", "assign", "--cluster-name", "stunning-sole", "--integration-name", "datadog-tp", "--ysql-config", "log_catalog=true,log_client=true,log_level=NOTICE,log_parameter=false,log_statement_once=false,log_relation=false", "--statement_classes", "READ,WRITE")
 			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
 			session.Wait(2)
 			Expect(session.Out).Should(gbytes.Say(`The db audit exporter config 9e3fabbc-849c-4a77-bdb2-9422e712e7dc is being created
 ID                                     Date Created               Cluster ID                             Integration ID                         State     Ysql Config
-9e3fabbc-849c-4a77-bdb2-9422e712e7dc   2024-02-27T06:30:51.304Z   7bb68af6-0875-42e0-8665-dcf634ed9fd1   7c07c103-e3b2-48b6-ac30-764e9b5275e1   ACTIVE    {\"log_settings\":{\"log_catalog\":true,\"log_client\":true,\"log_level\":\"LOG\",\"log_parameter\":false,\"log_relation\":false,\"log_statement_once\":false},\"statement_classes\":\[\"READ\",\"WRITE\"]}`))
+9e3fabbc-849c-4a77-bdb2-9422e712e7dc   2024-02-27T06:30:51.304Z   5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8   7c07c103-e3b2-48b6-ac30-764e9b5275e1   ACTIVE    {\"log_settings\":{\"log_catalog\":true,\"log_client\":true,\"log_level\":\"LOG\",\"log_parameter\":false,\"log_relation\":false,\"log_statement_once\":false},\"statement_classes\":\[\"READ\",\"WRITE\"]}`))
 			session.Kill()
 		})
 		It("should return required field name and type when not set", func() {
@@ -95,7 +105,7 @@ ID                                     Date Created               Cluster ID    
 			Expect(err).ToNot(HaveOccurred())
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
-					ghttp.VerifyRequest(http.MethodPost, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/clusters/7bb68af6-0875-42e0-8665-dcf634ed9fd1/db-audit-log-exporter-configs"),
+					ghttp.VerifyRequest(http.MethodPost, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/clusters/5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8/db-audit-log-exporter-configs"),
 					ghttp.RespondWithJSONEncodedPtr(&statusCode, responseDbAudit),
 				),
 			)
@@ -103,7 +113,7 @@ ID                                     Date Created               Cluster ID    
 			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
 			session.Wait(2)
-			Expect(session.Err).Should(gbytes.Say(`\bError: required flag\(s\) "integration-name", "ysql-config", "statement_classes", "cluster-id" not set\b`))
+			Expect(session.Err).Should(gbytes.Say(`\bError: required flag\(s\) "integration-name", "ysql-config", "statement_classes", "cluster-name" not set\b`))
 			session.Kill()
 		})
 		It("should return required log setting when not set", func() {
@@ -120,11 +130,11 @@ ID                                     Date Created               Cluster ID    
 			Expect(err).ToNot(HaveOccurred())
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
-					ghttp.VerifyRequest(http.MethodPost, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/clusters/7bb68af6-0875-42e0-8665-dcf634ed9fd1/db-audit-log-exporter-configs"),
+					ghttp.VerifyRequest(http.MethodPost, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/clusters/5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8/db-audit-log-exporter-configs"),
 					ghttp.RespondWithJSONEncodedPtr(&statusCode, responseDbAudit),
 				),
 			)
-			cmd := exec.Command(compiledCLIPath, "db-audit-logs-exporter", "assign", "--cluster-id", "7bb68af6-0875-42e0-8665-dcf634ed9fd1", "--integration-name", "datadog-tp", "--ysql-config", "log_catalog=true,log_client=true,log_level=NOTICE,log_parameter=false,log_relation=false", "--statement_classes", "READ,WRITE")
+			cmd := exec.Command(compiledCLIPath, "db-audit-logs-exporter", "assign", "--cluster-name", "stunning-sole", "--integration-name", "datadog-tp", "--ysql-config", "log_catalog=true,log_client=true,log_level=NOTICE,log_parameter=false,log_relation=false", "--statement_classes", "READ,WRITE")
 			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
 			session.Wait(2)
@@ -140,16 +150,16 @@ ID                                     Date Created               Cluster ID    
 			Expect(err).ToNot(HaveOccurred())
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
-					ghttp.VerifyRequest(http.MethodGet, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/clusters/7bb68af6-0875-42e0-8665-dcf634ed9fd1/db-audit-log-exporter-configs"),
+					ghttp.VerifyRequest(http.MethodGet, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/clusters/5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8/db-audit-log-exporter-configs"),
 					ghttp.RespondWithJSONEncodedPtr(&statusCode, responseDbAuditList),
 				),
 			)
-			cmd := exec.Command(compiledCLIPath, "db-audit-logs-exporter", "list", "--cluster-id", "7bb68af6-0875-42e0-8665-dcf634ed9fd1")
+			cmd := exec.Command(compiledCLIPath, "db-audit-logs-exporter", "list", "--cluster-name", "stunning-sole")
 			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
 			session.Wait(2)
 			Expect(session.Out).Should(gbytes.Say(`ID                                     Date Created               Cluster ID                             Integration ID                         State     Ysql Config
-9e3fabbc-849c-4a77-bdb2-9422e712e7dc   2024-02-27T06:30:51.304Z   7bb68af6-0875-42e0-8665-dcf634ed9fd1   7c07c103-e3b2-48b6-ac30-764e9b5275e1   ACTIVE    {\"log_settings\":{\"log_catalog\":true,\"log_client\":true,\"log_level\":\"LOG\",\"log_parameter\":false,\"log_relation\":false,\"log_statement_once\":false},\"statement_classes\":\[\"READ\",\"WRITE\"]}`))
+9e3fabbc-849c-4a77-bdb2-9422e712e7dc   2024-02-27T06:30:51.304Z   5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8   7c07c103-e3b2-48b6-ac30-764e9b5275e1   ACTIVE    {\"log_settings\":{\"log_catalog\":true,\"log_client\":true,\"log_level\":\"LOG\",\"log_parameter\":false,\"log_relation\":false,\"log_statement_once\":false},\"statement_classes\":\[\"READ\",\"WRITE\"]}`))
 			session.Kill()
 		})
 		It("should return required field name and type when not set", func() {
@@ -166,7 +176,7 @@ ID                                     Date Created               Cluster ID    
 			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
 			session.Wait(2)
-			Expect(session.Err).Should(gbytes.Say("(?m:Error: required flag\\(s\\) \"cluster-id\" not set$)"))
+			Expect(session.Err).Should(gbytes.Say("(?m:Error: required flag\\(s\\) \"cluster-name\" not set$)"))
 			session.Kill()
 		})
 
@@ -179,11 +189,11 @@ ID                                     Date Created               Cluster ID    
 			Expect(err).ToNot(HaveOccurred())
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
-					ghttp.VerifyRequest(http.MethodDelete, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/clusters/7bb68af6-0875-42e0-8665-dcf634ed9fd1/db-audit-log-exporter-configs/123e4567-e89b-12d3-a456-426614174000"),
+					ghttp.VerifyRequest(http.MethodDelete, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/clusters/5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8/db-audit-log-exporter-configs/123e4567-e89b-12d3-a456-426614174000"),
 					ghttp.RespondWithJSONEncodedPtr(&statusCode, responseDbAuditList),
 				),
 			)
-			cmd := exec.Command(compiledCLIPath, "db-audit-logs-exporter", "unassign", "--cluster-id", "7bb68af6-0875-42e0-8665-dcf634ed9fd1", "--export-config-id", "123e4567-e89b-12d3-a456-426614174000", "--force")
+			cmd := exec.Command(compiledCLIPath, "db-audit-logs-exporter", "unassign", "--cluster-name", "stunning-sole", "--export-config-id", "123e4567-e89b-12d3-a456-426614174000", "--force")
 			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
 			session.Wait(2)
@@ -197,7 +207,7 @@ ID                                     Date Created               Cluster ID    
 			exec.Command(compiledCLIPath, "y")
 			Expect(err).NotTo(HaveOccurred())
 			session.Wait(2)
-			Expect(session.Err).Should(gbytes.Say("(?m:Error: required flag\\(s\\) \"export-config-id\", \"cluster-id\" not set$)"))
+			Expect(session.Err).Should(gbytes.Say("(?m:Error: required flag\\(s\\) \"export-config-id\", \"cluster-name\" not set$)"))
 			session.Kill()
 		})
 

--- a/cmd/test/fixtures/db-audit-data.json
+++ b/cmd/test/fixtures/db-audit-data.json
@@ -19,7 +19,7 @@
         },
         "info": {
             "id": "9e3fabbc-849c-4a77-bdb2-9422e712e7dc",
-            "cluster_id": "7bb68af6-0875-42e0-8665-dcf634ed9fd1",
+            "cluster_id": "5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8",
             "state": "ACTIVE",
             "metadata": {
                 "created_on": "2024-02-27T06:30:51.304Z",

--- a/cmd/test/fixtures/list-db-audit.json
+++ b/cmd/test/fixtures/list-db-audit.json
@@ -20,7 +20,7 @@
             },
             "info": {
                 "id": "9e3fabbc-849c-4a77-bdb2-9422e712e7dc",
-                "cluster_id": "7bb68af6-0875-42e0-8665-dcf634ed9fd1",
+                "cluster_id": "5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8",
                 "state": "ACTIVE",
                 "metadata": {
                     "created_on": "2024-02-27T06:30:51.304Z",


### PR DESCRIPTION
## Summary
This change replaces `cluster-id` with `cluster-name` in DB audit commands. This is done to maintain uniformity with other commands

## Test Plan
Added UTs for the change.
Verified docs by turning on the feature flag
Manually tested the commands