### PR TITLE
[CLODUGA-20271] Add wait for DB audit commands

### DIFF
--- a/cmd/db_audit_logs_exporter_test.go
+++ b/cmd/db_audit_logs_exporter_test.go
@@ -185,19 +185,19 @@ ID                                     Date Created               Cluster ID    
 	Context("When removing db audit exporter config", func() {
 		It("should delete the config", func() {
 			statusCode = 200
-			err := loadJson("./test/fixtures/list-db-audit.json", &responseDbAuditList)
+			err := loadJson("./test/fixtures/db-audit-data.json", &responseDbAudit)
 			Expect(err).ToNot(HaveOccurred())
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
 					ghttp.VerifyRequest(http.MethodDelete, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/clusters/5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8/db-audit-log-exporter-configs/123e4567-e89b-12d3-a456-426614174000"),
-					ghttp.RespondWithJSONEncodedPtr(&statusCode, responseDbAuditList),
+					ghttp.RespondWithJSONEncodedPtr(&statusCode, responseDbAudit),
 				),
 			)
 			cmd := exec.Command(compiledCLIPath, "db-audit-logs-exporter", "unassign", "--cluster-name", "stunning-sole", "--export-config-id", "123e4567-e89b-12d3-a456-426614174000", "--force")
 			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
 			session.Wait(2)
-			Expect(session.Out).Should(gbytes.Say(`Deleting Db Audit Logs Exporter Config 123e4567-e89b-12d3-a456-426614174000`))
+			Expect(session.Out).Should(gbytes.Say(`Request submitted to remove Db Audit Logging 123e4567-e89b-12d3-a456-426614174000`))
 			session.Kill()
 		})
 		It("should return required field name and type when not set", func() {


### PR DESCRIPTION
## Summary
This PR adds wait to assign,unassign,delete commands for DB audit logging.
Also, improves error logging in unassign command.

## Test Plan
Manually tested all the commands with `--wait` flag. Refer the below screenshot for each usage.

Assign:
<img width="1644" alt="Screenshot 2024-04-29 at 10 55 23 AM" src="https://github.com/yugabyte/ybm-cli/assets/23431811/79c21f22-15ac-479c-a5a7-338f7b274247">
![Screenshot 2024-04-29 at 1 48 01 PM](https://github.com/yugabyte/ybm-cli/assets/23431811/5dfe1fce-67fd-43ec-af79-b00636b49964)

Update:
![Screenshot 2024-04-29 at 1 59 52 PM](https://github.com/yugabyte/ybm-cli/assets/23431811/01bae398-5adb-471e-916b-c0a10bea3e5f)
<img width="1654" alt="Screenshot 2024-04-29 at 2 10 33 PM" src="https://github.com/yugabyte/ybm-cli/assets/23431811/4fe55f26-062b-4018-b53e-dc831e6e010e">


Unassign:
<img width="1452" alt="Screenshot 2024-04-29 at 2 12 14 PM" src="https://github.com/yugabyte/ybm-cli/assets/23431811/4a3a5105-3971-4285-a2e6-073cf4862e56">
<img width="1453" alt="Screenshot 2024-04-29 at 2 34 29 PM" src="https://github.com/yugabyte/ybm-cli/assets/23431811/be0ab3e3-0614-4455-b8d5-24e9911ed1b3">

