### PR TITLE
Don't wait for task when it is not created

### DIFF
--- a/cmd/cluster/update_cluster.go
+++ b/cmd/cluster/update_cluster.go
@@ -157,7 +157,7 @@ var updateClusterCmd = &cobra.Command{
 		}
 		clusterData := []ybmclient.ClusterData{resp.GetData()}
 
-		msg := fmt.Sprintf("The cluster %s is being updated and will be updated soon if there are changes", formatter.Colorize(clusterName, formatter.GREEN_COLOR))
+		msg := fmt.Sprintf("The cluster %s is being updated and will begin updating if there are changes", formatter.Colorize(clusterName, formatter.GREEN_COLOR))
 
 		if viper.GetBool("wait") && !isNameChange {
 			returnStatus, err := authApi.WaitForTaskCompletion(clusterID, ybmclient.ENTITYTYPEENUM_CLUSTER, ybmclient.TASKTYPEENUM_EDIT_CLUSTER, []string{"FAILED", "SUCCEEDED"}, msg)

--- a/cmd/cluster/update_cluster.go
+++ b/cmd/cluster/update_cluster.go
@@ -157,7 +157,7 @@ var updateClusterCmd = &cobra.Command{
 		}
 		clusterData := []ybmclient.ClusterData{resp.GetData()}
 
-		msg := fmt.Sprintf("The cluster %s is being updated", formatter.Colorize(clusterName, formatter.GREEN_COLOR))
+		msg := fmt.Sprintf("The cluster %s is being updated and will be updated soon if there are changes", formatter.Colorize(clusterName, formatter.GREEN_COLOR))
 
 		if viper.GetBool("wait") && !isNameChange {
 			returnStatus, err := authApi.WaitForTaskCompletion(clusterID, ybmclient.ENTITYTYPEENUM_CLUSTER, ybmclient.TASKTYPEENUM_EDIT_CLUSTER, []string{"FAILED", "SUCCEEDED"}, msg)

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1347,6 +1347,8 @@ func (a *AuthApiClient) WaitForTaskCompletionCI(entityId string, entityType ybmc
 							output = output + "\n" + ". Task " + strconv.Itoa(index+1) + ": " + action.GetName() + " " + strconv.Itoa(int(action.GetPercentComplete())) + "% completed"
 						}
 					}
+				} else {
+					currentStatus = "SUCCEEDED"
 				}
 			}
 			if slices.Contains(completionStatus, currentStatus) {
@@ -1410,6 +1412,8 @@ func (a *AuthApiClient) WaitForTaskCompletionFull(entityId string, entityType yb
 							output = output + "\n" + ". Task " + strconv.Itoa(index+1) + ": " + action.GetName() + " " + strconv.Itoa(int(action.GetPercentComplete())) + "% completed"
 						}
 					}
+				} else {
+					currentStatus = "SUCCEEDED"
 				}
 			}
 			s.Suffix = output


### PR DESCRIPTION
Sometimes, when the cluster spec doesn't change, no task is spawned. In such cases, we need not wait for task completion.