### PR TITLE
PITR CLI

### DIFF
--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -19,8 +19,10 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/yugabyte/ybm-cli/cmd/cluster/cert"
 	encryption "github.com/yugabyte/ybm-cli/cmd/cluster/encryption"
+	"github.com/yugabyte/ybm-cli/cmd/cluster/namespace"
 	"github.com/yugabyte/ybm-cli/cmd/cluster/network"
 	"github.com/yugabyte/ybm-cli/cmd/cluster/node"
+	"github.com/yugabyte/ybm-cli/cmd/cluster/pitr-config"
 	readreplica "github.com/yugabyte/ybm-cli/cmd/cluster/read-replica"
 )
 
@@ -52,4 +54,12 @@ func init() {
 	ClusterCmd.AddCommand(encryption.EncryptionCmd)
 	encryption.EncryptionCmd.PersistentFlags().StringP("cluster-name", "c", "", "[REQUIRED] The name of the cluster.")
 	encryption.EncryptionCmd.MarkPersistentFlagRequired("cluster-name")
+
+	ClusterCmd.AddCommand(namespace.NamespaceCmd)
+	namespace.NamespaceCmd.PersistentFlags().StringP("cluster-name", "c", "", "[REQUIRED] The name of the cluster.")
+	namespace.NamespaceCmd.MarkPersistentFlagRequired("cluster-name")
+
+	ClusterCmd.AddCommand(pitrconfig.PitrConfigCmd)
+	pitrconfig.PitrConfigCmd.PersistentFlags().StringP("cluster-name", "c", "", "[REQUIRED] The name of the cluster.")
+	pitrconfig.PitrConfigCmd.MarkPersistentFlagRequired("cluster-name")
 }

--- a/cmd/cluster/namespace/namespace.go
+++ b/cmd/cluster/namespace/namespace.go
@@ -1,0 +1,74 @@
+// Licensed to Yugabyte, Inc. under one or more contributor license
+// agreements. See the NOTICE file distributed with this work for
+// additional information regarding copyright ownership. Yugabyte
+// licenses this file to you under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package namespace
+
+import (
+	"os"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	ybmAuthClient "github.com/yugabyte/ybm-cli/internal/client"
+	"github.com/yugabyte/ybm-cli/internal/formatter"
+)
+
+var NamespaceCmd = &cobra.Command{
+	Use:   "namespace",
+	Short: "Manage Cluster Namespaces",
+	Long:  "Manage Cluster namespaces",
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Help()
+	},
+}
+
+var listNamespaceCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List namespaces for a cluster",
+	Long:  "List namespaces on your YugabyteDB Aeon cluster",
+	Run: func(cmd *cobra.Command, args []string) {
+		authApi, err := ybmAuthClient.NewAuthApiClient()
+		if err != nil {
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
+		}
+		authApi.GetInfo("", "")
+
+		clusterName, _ := cmd.Flags().GetString("cluster-name")
+		clusterId, err := authApi.GetClusterIdByName(clusterName)
+		if err != nil {
+			logrus.Fatalf("%s", ybmAuthClient.GetApiErrorDetails(err))
+		}
+
+		resp, r, err := authApi.GetClusterNamespaces(clusterId).Execute()
+		if err != nil {
+			logrus.Debugf("Full HTTP response: %v", r)
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
+		}
+
+		if len(resp.GetData()) == 0 {
+			logrus.Fatalf("No namespaces found.\n")
+		}
+
+		namespaceCtx := formatter.Context{
+			Output: os.Stdout,
+			Format: formatter.NewNamespaceFormat(viper.GetString("output")),
+		}
+		formatter.NamespaceWrite(namespaceCtx, resp.GetData())
+	},
+}
+
+func init() {
+	NamespaceCmd.AddCommand(listNamespaceCmd)
+}

--- a/cmd/cluster/pitr-config/pitr_config.go
+++ b/cmd/cluster/pitr-config/pitr_config.go
@@ -1,0 +1,33 @@
+// Licensed to Yugabyte, Inc. under one or more contributor license
+// agreements. See the NOTICE file distributed with this work for
+// additional information regarding copyright ownership. Yugabyte
+// licenses this file to you under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package pitrconfig
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var PitrConfigCmd = &cobra.Command{
+	Use:   "pitr-config",
+	Short: "Manage Cluster PITR Configs",
+	Long:  "Manage Cluster PITR Configs",
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Help()
+	},
+}
+
+func init() {
+	PitrConfigCmd.AddCommand()
+}

--- a/cmd/cluster/pitr-config/pitr_config_ops.go
+++ b/cmd/cluster/pitr-config/pitr_config_ops.go
@@ -1,0 +1,192 @@
+// Licensed to Yugabyte, Inc. under one or more contributor license
+// agreements. See the NOTICE file distributed with this work for
+// additional information regarding copyright ownership. Yugabyte
+// licenses this file to you under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package pitrconfig
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/yugabyte/ybm-cli/cmd/util"
+	ybmAuthClient "github.com/yugabyte/ybm-cli/internal/client"
+	"github.com/yugabyte/ybm-cli/internal/formatter"
+)
+
+var ClusterName string
+
+var listPitrConfigCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List PITR Configs for a cluster",
+	Long:  "List PITR Configs for a cluster in YugabyteDB Aeon",
+	Run: func(cmd *cobra.Command, args []string) {
+		authApi, err := ybmAuthClient.NewAuthApiClient()
+		if err != nil {
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
+		}
+		authApi.GetInfo("", "")
+		clusterID, err := authApi.GetClusterIdByName(ClusterName)
+		if err != nil {
+			logrus.Fatal(err)
+		}
+		resp, r, err := authApi.ListClusterPitrConfigs(clusterID).Execute()
+		if err != nil {
+			logrus.Debugf("Full HTTP response: %v", r)
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
+		}
+
+		if len(resp.GetData()) < 1 {
+			logrus.Info("No PITR Configs found for cluster.\n")
+			return
+		}
+
+		pitrConfigCtx := formatter.Context{
+			Output: os.Stdout,
+			Format: formatter.NewPitrConfigFormat(viper.GetString("output")),
+		}
+
+		formatter.PitrConfigWrite(pitrConfigCtx, resp.GetData())
+
+	},
+}
+
+var createPitrConfigCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create PITR Config for a cluster",
+	Long:  "Create PITR Config for a cluster in YugabyteDB Aeon",
+	Run: func(cmd *cobra.Command, args []string) {
+		authApi, err := ybmAuthClient.NewAuthApiClient()
+		if err != nil {
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
+		}
+		authApi.GetInfo("", "")
+		clusterID, err := authApi.GetClusterIdByName(ClusterName)
+		if err != nil {
+			logrus.Fatal(err)
+		}
+
+		namespaceName, _ := cmd.Flags().GetString("namespace-name")
+		namespaceType, _ := cmd.Flags().GetString("namespace-type")
+		retentionPeriod, _ := cmd.Flags().GetInt32("retention-period-in-days")
+
+		if !(namespaceType == "YCQL" || namespaceType == "YSQL") {
+			logrus.Fatalln("Only YCQL or YSQL namespace types are allowed.")
+		}
+
+		pitrConfigSpec, err := authApi.CreatePitrConfigSpec(namespaceName, namespaceType, retentionPeriod)
+		if err != nil {
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
+		}
+
+		resp, r, err := authApi.CreatePitrConfig(clusterID).DatabasePitrConfigSpec(*pitrConfigSpec).Execute()
+		if err != nil {
+			logrus.Debugf("Full HTTP response: %v", r)
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
+		}
+
+		fmt.Printf("\nSuccessfully created PITR configuration.\n\n")
+
+		pitrConfigCtx := formatter.Context{
+			Output: os.Stdout,
+			Format: formatter.NewPitrConfigFormat(viper.GetString("output")),
+		}
+
+		formatter.SinglePitrConfigWrite(pitrConfigCtx, resp.GetData())
+	},
+}
+
+var restorePitrConfigCmd = &cobra.Command{
+	Use:   "restore",
+	Short: "Restore namespace via PITR Config for a cluster",
+	Long:  "Restore namespace via PITR Config for a cluster in YugabyteDB Aeon",
+	PreRun: func(cmd *cobra.Command, args []string) {
+		viper.BindPFlag("force", cmd.Flags().Lookup("force"))
+		namespaceName, _ := cmd.Flags().GetString("namespace-name")
+		restoreAtMilis, _ := cmd.Flags().GetInt64("restore-at-millis")
+		err := util.ConfirmCommand(fmt.Sprintf("Are you sure you want to restore the namespace: %s at %d", namespaceName, restoreAtMilis), viper.GetBool("force"))
+		if err != nil {
+			logrus.Fatal(err)
+		}
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		authApi, err := ybmAuthClient.NewAuthApiClient()
+		if err != nil {
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
+		}
+		authApi.GetInfo("", "")
+		clusterID, err := authApi.GetClusterIdByName(ClusterName)
+		if err != nil {
+			logrus.Fatal(err)
+		}
+
+		namespaceName, _ := cmd.Flags().GetString("namespace-name")
+		restoreAtMilis, _ := cmd.Flags().GetInt64("restore-at-millis")
+
+		var pitrConfigId string
+		listConfigsResp, listConfigsResponse, listConfigsError := authApi.ListClusterPitrConfigs(clusterID).Execute()
+		if err != nil {
+			logrus.Debugf("Full HTTP response: %v", listConfigsResponse)
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(listConfigsError))
+		}
+
+		for _, pitrConfig := range listConfigsResp.GetData() {
+			if pitrConfig.Spec.DatabaseName == namespaceName {
+				pitrConfigId = *pitrConfig.Info.Id
+				break
+			}
+		}
+
+		if len(pitrConfigId) == 0 {
+			logrus.Fatalf("No PITR Configs found for namespace %s\n", namespaceName)
+		}
+
+		restoreViaPitrConfigSpec, err := authApi.CreateRestoreViaPitrConfigSpec(restoreAtMilis)
+		if err != nil {
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
+		}
+
+		_, r, err := authApi.RestoreViaPitrConfig(clusterID, pitrConfigId).DatabaseRestoreViaPitrSpec(*restoreViaPitrConfigSpec).Execute()
+		if err != nil {
+			logrus.Debugf("Full HTTP response: %v", r)
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
+		}
+
+		fmt.Printf("\nSuccessfully restored namespace %s at %d ms.\n\n", namespaceName, restoreAtMilis)
+	},
+}
+
+func init() {
+	util.AddCommandIfFeatureFlag(PitrConfigCmd, listPitrConfigCmd, util.PITR_CONFIG)
+
+	util.AddCommandIfFeatureFlag(PitrConfigCmd, createPitrConfigCmd, util.PITR_CONFIG)
+	createPitrConfigCmd.Flags().SortFlags = false
+	createPitrConfigCmd.Flags().String("namespace-name", "", "[REQUIRED] Namespace for which the PITR Config is to be created.")
+	createPitrConfigCmd.MarkFlagRequired("namespace-name")
+	createPitrConfigCmd.Flags().String("namespace-type", "", "[REQUIRED] The type of the namespace. Available options are YCQL and YSQL")
+	createPitrConfigCmd.MarkFlagRequired("namespace-type")
+	createPitrConfigCmd.Flags().Int32("retention-period-in-days", 1, "[REQUIRED] The time duration in days to retain a snapshot for.")
+	createPitrConfigCmd.MarkFlagRequired("retention-period-in-days")
+
+	util.AddCommandIfFeatureFlag(PitrConfigCmd, restorePitrConfigCmd, util.PITR_CONFIG)
+	restorePitrConfigCmd.Flags().SortFlags = false
+	restorePitrConfigCmd.Flags().String("namespace-name", "", "[REQUIRED] Namespace to be restored via PITR Config.")
+	restorePitrConfigCmd.MarkFlagRequired("namespace-name")
+	restorePitrConfigCmd.Flags().Int64("restore-at-millis", 1, "[REQUIRED] The time in milliseconds to which the namespace is to be restored")
+	restorePitrConfigCmd.MarkFlagRequired("restore-at-millis")
+	restorePitrConfigCmd.Flags().BoolP("force", "f", false, "Bypass the prompt for non-interactive usage")
+
+}

--- a/cmd/cluster/read-replica/read_replica_test.go
+++ b/cmd/cluster/read-replica/read_replica_test.go
@@ -28,9 +28,6 @@ var _ = Describe("Read Replica utils", func() {
 			n := int32(1)
 			numReplicas := ybmclient.NewNullableInt32(&n)
 			correctSpec := ybmclient.ReadReplicaSpec{
-				NodeInfo: ybmclient.ClusterNodeInfo{
-					NumCores: 2,
-				},
 				PlacementInfo: ybmclient.PlacementInfo{
 					CloudInfo: ybmclient.CloudInfo{
 						Code:   "AWS",
@@ -41,6 +38,10 @@ var _ = Describe("Read Replica utils", func() {
 					NumReplicas: *numReplicas,
 				},
 			}
+			nodeInfo := ybmclient.ClusterNodeInfo{
+				NumCores: 2,
+			}
+			correctSpec.SetNodeInfo(nodeInfo)
 			spec := readreplica.GetDefaultSpec(ybmclient.CLOUDENUM_AWS, vpcId)
 			Expect(spec).To(BeEquivalentTo(correctSpec))
 		})

--- a/cmd/cluster/update_cluster.go
+++ b/cmd/cluster/update_cluster.go
@@ -248,16 +248,16 @@ func populateFlags(cmd *cobra.Command, originalSpec ybmclient.ClusterSpec, track
 	}
 	if !cmd.Flags().Changed("node-config") {
 		nodeConfig := ""
-		if diskSizeGb, ok := originalSpec.ClusterInfo.NodeInfo.GetDiskSizeGbOk(); ok {
+		if diskSizeGb, ok := originalSpec.ClusterInfo.NodeInfo.Get().GetDiskSizeGbOk(); ok {
 			nodeConfig += "disk-size-gb=" + strconv.Itoa(int(*diskSizeGb))
 		}
-		if diskIops, ok := originalSpec.ClusterInfo.NodeInfo.GetDiskIopsOk(); ok && diskIops != nil {
+		if diskIops, ok := originalSpec.ClusterInfo.NodeInfo.Get().GetDiskIopsOk(); ok && diskIops != nil {
 			if nodeConfig != "" {
 				nodeConfig += ","
 			}
 			nodeConfig += "disk-iops=" + strconv.Itoa(int(*diskIops))
 		}
-		if numCores, ok := originalSpec.ClusterInfo.NodeInfo.GetNumCoresOk(); ok {
+		if numCores, ok := originalSpec.ClusterInfo.NodeInfo.Get().GetNumCoresOk(); ok {
 			if nodeConfig != "" {
 				nodeConfig += ","
 			}

--- a/cmd/db_audit_logs_exporter/db_audit_logs_exporter.go
+++ b/cmd/db_audit_logs_exporter/db_audit_logs_exporter.go
@@ -24,11 +24,11 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"github.com/yugabyte/ybm-cli/cmd/util"
 	ybmAuthClient "github.com/yugabyte/ybm-cli/internal/client"
 	"github.com/yugabyte/ybm-cli/internal/formatter"
 	openapi "github.com/yugabyte/yugabytedb-managed-go-client-internal"
 	ybmclient "github.com/yugabyte/yugabytedb-managed-go-client-internal"
-	"github.com/yugabyte/ybm-cli/cmd/util"
 )
 
 var DbAuditLogsExporterCmd = &cobra.Command{
@@ -329,10 +329,10 @@ func init() {
 	removeDbAuditLogsExporterCmd.Flags().BoolP("force", "f", false, "Bypass the prompt for non-interactive usage")
 }
 
-func getIntegrationIdFromName(integrationName string, authApi *ybmAuthClient.AuthApiClient) (string, error){
+func getIntegrationIdFromName(integrationName string, authApi *ybmAuthClient.AuthApiClient) (string, error) {
 	integration, _, err := authApi.ListIntegrations().Name(integrationName).Execute()
 	if err != nil {
-		return "" , err
+		return "", err
 	}
 
 	integrationData := integration.GetData()
@@ -375,7 +375,7 @@ func setDbAuditLogsExporterSpec(ysqlConfigMap map[string]string, statementClasse
 			return nil, err
 		}
 		log_settings.SetLogCatalog(catalog)
-	}else{
+	} else {
 		return nil, fmt.Errorf("log_catalog required for log settings")
 	}
 
@@ -385,7 +385,7 @@ func setDbAuditLogsExporterSpec(ysqlConfigMap map[string]string, statementClasse
 			return nil, err
 		}
 		log_settings.SetLogClient(client)
-	}else{
+	} else {
 		return nil, fmt.Errorf("log_client required for log settings")
 	}
 
@@ -395,7 +395,7 @@ func setDbAuditLogsExporterSpec(ysqlConfigMap map[string]string, statementClasse
 			return nil, err
 		}
 		log_settings.SetLogLevel(*level)
-	}else{
+	} else {
 		return nil, fmt.Errorf("log_level required for log settings")
 	}
 
@@ -405,7 +405,7 @@ func setDbAuditLogsExporterSpec(ysqlConfigMap map[string]string, statementClasse
 			return nil, err
 		}
 		log_settings.SetLogParameter(parameter)
-	}else{
+	} else {
 		return nil, fmt.Errorf("log_parameter required for log settings")
 	}
 
@@ -415,7 +415,7 @@ func setDbAuditLogsExporterSpec(ysqlConfigMap map[string]string, statementClasse
 			return nil, err
 		}
 		log_settings.SetLogRelation(relation)
-	}else{
+	} else {
 		return nil, fmt.Errorf("log_relation required for log settings")
 	}
 
@@ -425,7 +425,7 @@ func setDbAuditLogsExporterSpec(ysqlConfigMap map[string]string, statementClasse
 			return nil, err
 		}
 		log_settings.SetLogStatementOnce(statement_once)
-	}else{
+	} else {
 		return nil, fmt.Errorf("log_statement_once required for log settings")
 	}
 

--- a/cmd/db_audit_logs_exporter_test.go
+++ b/cmd/db_audit_logs_exporter_test.go
@@ -32,13 +32,13 @@ import (
 var _ = Describe("Db Audit", func() {
 
 	var (
-		server              	*ghttp.Server
-		statusCode          	int
-		args                	[]string
-		responseAccount     	openapi.AccountListResponse
-		responseProject     	openapi.AccountListResponse
-		responseDbAudit     	openapi.DbAuditExporterConfigResponse
-		responseDbAuditList 	openapi.DbAuditExporterConfigListResponse
+		server                  *ghttp.Server
+		statusCode              int
+		args                    []string
+		responseAccount         openapi.AccountListResponse
+		responseProject         openapi.AccountListResponse
+		responseDbAudit         openapi.DbAuditExporterConfigResponse
+		responseDbAuditList     openapi.DbAuditExporterConfigListResponse
 		responseIntegrationList openapi.TelemetryProviderListResponse
 		responseListClusters    openapi.ClusterListResponse
 	)

--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"strings"
 
+	"encoding/json"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -27,7 +28,6 @@ import (
 	ybmAuthClient "github.com/yugabyte/ybm-cli/internal/client"
 	"github.com/yugabyte/ybm-cli/internal/formatter"
 	ybmclient "github.com/yugabyte/yugabytedb-managed-go-client-internal"
-	"encoding/json"
 	"io"
 )
 
@@ -174,7 +174,6 @@ func init() {
 	access-key=<your-sumologic-access-key>,access-id=<your-sumologic-access-id>,installation-token=<your-sumologic-installation-token>`)
 	createIntegrationCmd.Flags().String("googlecloud-cred-filepath", "", `Filepath for Google Cloud service account credentials. 
 	Please provide absolute file path`)
-	
 
 	IntegrationCmd.AddCommand(listIntegrationCmd)
 

--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -32,13 +32,13 @@ import (
 var _ = Describe("Integration", func() {
 
 	var (
-		server              			*ghttp.Server
-		statusCode          			int
-		args                			[]string
-		responseAccount     			openapi.AccountListResponse
-		responseProject     			openapi.AccountListResponse
-		responseIntegration   			openapi.TelemetryProviderResponse
-		responseIntegrationList 		openapi.TelemetryProviderListResponse
+		server                  *ghttp.Server
+		statusCode              int
+		args                    []string
+		responseAccount         openapi.AccountListResponse
+		responseProject         openapi.AccountListResponse
+		responseIntegration     openapi.TelemetryProviderResponse
+		responseIntegrationList openapi.TelemetryProviderListResponse
 	)
 
 	BeforeEach(func() {

--- a/cmd/namespace_test.go
+++ b/cmd/namespace_test.go
@@ -1,0 +1,79 @@
+package cmd_test
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gexec"
+	"github.com/onsi/gomega/ghttp"
+	openapi "github.com/yugabyte/yugabytedb-managed-go-client-internal"
+)
+
+var _ = Describe("Namespaces", func() {
+
+	var (
+		server              *ghttp.Server
+		statusCode          int
+		args                []string
+		responseAccount     openapi.AccountListResponse
+		responseProject     openapi.AccountListResponse
+		responseListCluster openapi.ClusterListResponse
+		responseNamespace   openapi.ClusterNamespacesListResponse
+	)
+
+	BeforeEach(func() {
+		args = os.Args
+		os.Args = []string{}
+		var err error
+		server, err = newGhttpServer(responseAccount, responseProject)
+		Expect(err).ToNot(HaveOccurred())
+		os.Setenv("YBM_HOST", fmt.Sprintf("http://%s", server.Addr()))
+		os.Setenv("YBM_APIKEY", "test-token")
+
+		statusCode = 200
+		err = loadJson("./test/fixtures/list-clusters.json", &responseListCluster)
+		Expect(err).ToNot(HaveOccurred())
+		server.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/clusters"),
+				ghttp.RespondWithJSONEncodedPtr(&statusCode, responseListCluster),
+			),
+		)
+
+		statusCode = 200
+		err = loadJson("./test/fixtures/namespaces.json", &responseNamespace)
+		Expect(err).ToNot(HaveOccurred())
+		server.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/clusters/5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8/namespaces"),
+				ghttp.RespondWithJSONEncodedPtr(&statusCode, responseNamespace),
+			),
+		)
+	})
+
+	Context("When listing namespaces", func() {
+		It("should return the list of namespaces", func() {
+			cmd := exec.Command(compiledCLIPath, "cluster", "namespace", "list", "--cluster-name", "stunning-sole")
+			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+			session.Wait(2)
+			Expect(session.Out).Should(gbytes.Say(`Namespace      Table Type
+postgres       YSQL
+test_ycql_db   YCQL
+test_ysql_db   YSQL
+yugabyte       YSQL`))
+			session.Kill()
+		})
+
+	})
+
+	AfterEach(func() {
+		os.Args = args
+		server.Close()
+	})
+})

--- a/cmd/pitr_config_test.go
+++ b/cmd/pitr_config_test.go
@@ -1,0 +1,153 @@
+package cmd_test
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	// "strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gexec"
+	"github.com/onsi/gomega/ghttp"
+	openapi "github.com/yugabyte/yugabytedb-managed-go-client-internal"
+)
+
+var _ = Describe("PITR Configs Test", func() {
+
+	var (
+		server                       *ghttp.Server
+		statusCode                   int
+		args                         []string
+		responseAccount              openapi.AccountListResponse
+		responseProject              openapi.AccountListResponse
+		responseListCluster          openapi.ClusterListResponse
+		responseListPITRConfig       openapi.ClusterPitrConfigListResponse
+		responseCreatePITRConfig     openapi.CreateDatabasePitrConfigResponse
+		responseRestoreViaPITRConfig openapi.RestoreDatabaseViaPitrResponse
+	)
+
+	BeforeEach(func() {
+		args = os.Args
+		os.Args = []string{}
+		var err error
+		server, err = newGhttpServer(responseAccount, responseProject)
+		Expect(err).ToNot(HaveOccurred())
+		os.Setenv("YBM_HOST", fmt.Sprintf("http://%s", server.Addr()))
+		os.Setenv("YBM_APIKEY", "test-token")
+		os.Setenv("YBM_FF_PITR_CONFIG", "true")
+
+		statusCode = 200
+		err = loadJson("./test/fixtures/list-clusters.json", &responseListCluster)
+		Expect(err).ToNot(HaveOccurred())
+		server.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/clusters"),
+				ghttp.RespondWithJSONEncodedPtr(&statusCode, responseListCluster),
+			),
+		)
+	})
+
+	var _ = Describe("List Cluster PITR Configs", func() {
+		It("Should successfully list PITR Configs for the cluster", func() {
+			err := loadJson("./test/fixtures/list-cluster-pitr-configs.json", &responseListPITRConfig)
+			Expect(err).ToNot(HaveOccurred())
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/clusters/5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8/pitr-configs"),
+					ghttp.RespondWithJSONEncodedPtr(&statusCode, responseListPITRConfig),
+				),
+			)
+			cmd := exec.Command(compiledCLIPath, "cluster", "pitr-config", "list", "--cluster-name", "stunning-sole")
+			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+			session.Wait(2)
+			Expect(session.Out).Should(gbytes.Say(`Namespace      Table Type   Retention Period in Days   Backup Interval in Seconds   State     Date Created
+test_ycql_db   YCQL         6                          86400                        ACTIVE    2024-08-03T11:38:10.838Z
+test_ysql_db   YSQL         5                          86400                        QUEUED    2024-08-03T11:34:06.456Z`))
+			session.Kill()
+		})
+
+		It("should fail if no PITR Configs found for the cluster", func() {
+			responseListPITRConfig = *openapi.NewClusterPitrConfigListResponse()
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/clusters/5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8/pitr-configs"),
+					ghttp.RespondWithJSONEncodedPtr(&statusCode, responseListPITRConfig),
+				),
+			)
+			cmd := exec.Command(compiledCLIPath, "cluster", "pitr-config", "list", "--cluster-name", "stunning-sole")
+			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+			session.Wait(2)
+			Expect(session.Err).Should(gbytes.Say("No PITR Configs found for cluster.\n"))
+			session.Kill()
+		})
+	})
+
+	var _ = Describe("Create PITR config", func() {
+		It("Should successfully create PITR config", func() {
+			err := loadJson("./test/fixtures/create-cluster-pitr-config.json", &responseCreatePITRConfig)
+			Expect(err).ToNot(HaveOccurred())
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodPost, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/clusters/5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8/pitr-configs"),
+					ghttp.RespondWithJSONEncodedPtr(&statusCode, responseCreatePITRConfig),
+				),
+			)
+			cmd := exec.Command(compiledCLIPath, "cluster", "pitr-config", "create", "--cluster-name", "stunning-sole", "--namespace-name", "test_ysql_db", "--namespace-type", "YSQL", "--retention-period-in-days", "5")
+			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+			session.Wait(2)
+			Expect(session.Out).Should(gbytes.Say(`Successfully created PITR configuration.
+
+Namespace      Table Type   Retention Period in Days   Backup Interval in Seconds   State     Date Created
+test_ysql_db   YSQL         5                          86400                        QUEUED    2024-08-07T16:26:08.435Z`))
+			session.Kill()
+		})
+	})
+
+	It("Should fail if invalid namespace type in PITR Config", func() {
+		cmd := exec.Command(compiledCLIPath, "cluster", "pitr-config", "create", "--cluster-name", "stunning-sole", "--namespace-name", "test_ysql_db", "--namespace-type", "PGSQL", "--retention-period-in-days", "5")
+		session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+		Expect(err).NotTo(HaveOccurred())
+		session.Wait(2)
+		Expect(session.Err).Should(gbytes.Say("Only YCQL or YSQL namespace types are allowed."))
+		session.Kill()
+	})
+
+	var _ = Describe("Restore cluster namespace via PITR config", func() {
+		It("Should successfully restore namespace via PITR Config", func() {
+			err := loadJson("./test/fixtures/list-cluster-pitr-configs.json", &responseListPITRConfig)
+			Expect(err).ToNot(HaveOccurred())
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/clusters/5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8/pitr-configs"),
+					ghttp.RespondWithJSONEncodedPtr(&statusCode, responseListPITRConfig),
+				),
+			)
+			restoreErr := loadJson("./test/fixtures/restore-cluster-database-via-pitr-config.json", &responseRestoreViaPITRConfig)
+			Expect(restoreErr).ToNot(HaveOccurred())
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodPost, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/clusters/5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8/pitr-configs/07de8b5e-ce57-4ab5-8e29-97e57b20e76f/restore"),
+					ghttp.RespondWithJSONEncodedPtr(&statusCode, responseRestoreViaPITRConfig),
+				),
+			)
+
+			cmd := exec.Command(compiledCLIPath, "cluster", "pitr-config", "restore", "--cluster-name", "stunning-sole", "--namespace-name", "test_ysql_db", "--restore-at-millis", "4567", "--force")
+			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+			session.Wait(2)
+			Expect(session.Out).Should(gbytes.Say("Successfully restored namespace test_ysql_db at 4567 ms."))
+			session.Kill()
+		})
+	})
+
+	AfterEach(func() {
+		os.Args = args
+		server.Close()
+	})
+})

--- a/cmd/test/fixtures/create-cluster-pitr-config.json
+++ b/cmd/test/fixtures/create-cluster-pitr-config.json
@@ -1,0 +1,19 @@
+{
+    "data": {
+      "spec": {
+        "database_type": "YSQL",
+        "database_name": "test_ysql_db",
+        "retention_period": 5
+      },
+      "info": {
+        "id": "3fb11555-b561-4e8f-b0ed-e77b8374cbc3",
+        "cluster_id": "95c522b3-dfd8-4654-ab10-99f59179ad7c",
+        "metadata": {
+          "created_on": "2024-08-07T16:26:08.435Z",
+          "updated_on": "2024-08-07T16:26:08.435Z"
+        },
+        "backup_interval": 86400,
+        "state": "QUEUED"
+      }
+    }
+  }

--- a/cmd/test/fixtures/list-cluster-pitr-configs.json
+++ b/cmd/test/fixtures/list-cluster-pitr-configs.json
@@ -1,0 +1,38 @@
+{
+  "data": [
+    {
+      "spec": {
+        "database_type": "YSQL",
+        "database_name": "test_ysql_db",
+        "retention_period": 5
+      },
+      "info": {
+        "id": "07de8b5e-ce57-4ab5-8e29-97e57b20e76f",
+        "cluster_id": "95c522b3-dfd8-4654-ab10-99f59179ad7c",
+        "metadata": {
+          "created_on": "2024-08-03T11:34:06.456Z",
+          "updated_on": "2024-08-03T11:34:06.456Z"
+        },
+        "backup_interval": 86400,
+        "state": "QUEUED"
+      }
+    },
+    {
+      "spec": {
+        "database_type": "YCQL",
+        "database_name": "test_ycql_db",
+        "retention_period": 6
+      },
+      "info": {
+        "id": "249f9bf1-4276-4c60-8ab3-2bf1b2f6f1aa",
+        "cluster_id": "95c522b3-dfd8-4654-ab10-99f59179ad7c",
+        "metadata": {
+          "created_on": "2024-08-03T11:38:10.838Z",
+          "updated_on": "2024-08-03T11:38:10.838Z"
+        },
+        "backup_interval": 86400,
+        "state": "ACTIVE"
+      }
+    }
+  ]
+}

--- a/cmd/test/fixtures/namespaces.json
+++ b/cmd/test/fixtures/namespaces.json
@@ -1,0 +1,24 @@
+{
+    "data": [
+        {
+            "name": "test_ycql_db",
+            "id": "9671367e-72c9-4593-be50-418cae59bf45",
+            "table_type": "YQL_TABLE_TYPE"
+        },
+        {
+            "name": "postgres",
+            "id": "000033c1-0000-3000-8000-000000000000",
+            "table_type": "PGSQL_TABLE_TYPE"
+        },
+        {
+            "name": "yugabyte",
+            "id": "000033c3-0000-3000-8000-000000000000",
+            "table_type": "PGSQL_TABLE_TYPE"
+        },
+        {
+            "name": "test_ysql_db",
+            "id": "00004002-0000-3000-8000-000000000000",
+            "table_type": "PGSQL_TABLE_TYPE"
+        }
+    ]
+}

--- a/cmd/test/fixtures/restore-cluster-database-via-pitr-config.json
+++ b/cmd/test/fixtures/restore-cluster-database-via-pitr-config.json
@@ -1,0 +1,17 @@
+{
+  "data": {
+    "spec": {
+      "restore_at_millis": 1234556
+    },
+    "info": {
+      "cluster_id": "5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8",
+      "metadata": {
+        "updated_on": "2024-08-07T17:26:08.435Z",
+        "created_on": "2024-08-07T17:26:08.435Z"
+      },
+      "pitr_config_id": "07de8b5e-ce57-4ab5-8e29-97e57b20e76f",
+      "id": "9e74ca8f-331b-4dec-89b0-4e59b81e905c",
+      "state": "QUEUED"
+    }
+  }
+}

--- a/cmd/util/feature_flags.go
+++ b/cmd/util/feature_flags.go
@@ -32,6 +32,7 @@ const (
 	AZURE_CIDR_ALLOWED  FeatureFlag = "AZURE_CIDR_ALLOWED"
 	ENTERPRISE_SECURITY FeatureFlag = "ENTERPRISE_SECURITY"
 	DB_AUDIT_LOGS       FeatureFlag = "DB_AUDIT_LOGS"
+	PITR_CONFIG         FeatureFlag = "PITR_CONFIG"
 )
 
 func (f FeatureFlag) String() string {

--- a/docs/ybm.md
+++ b/docs/ybm.md
@@ -17,6 +17,7 @@ ybm [flags]
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
   -h, --help               help for ybm
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_api-key.md
+++ b/docs/ybm_api-key.md
@@ -22,6 +22,7 @@ ybm api-key [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_api-key_create.md
+++ b/docs/ybm_api-key_create.md
@@ -28,6 +28,7 @@ ybm api-key create [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_api-key_list.md
+++ b/docs/ybm_api-key_list.md
@@ -24,6 +24,7 @@ ybm api-key list [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_api-key_revoke.md
+++ b/docs/ybm_api-key_revoke.md
@@ -24,6 +24,7 @@ ybm api-key revoke [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_auth.md
+++ b/docs/ybm_auth.md
@@ -22,6 +22,7 @@ ybm auth [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_backup.md
+++ b/docs/ybm_backup.md
@@ -22,6 +22,7 @@ ybm backup [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_backup_create.md
+++ b/docs/ybm_backup_create.md
@@ -25,6 +25,7 @@ ybm backup create [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_backup_delete.md
+++ b/docs/ybm_backup_delete.md
@@ -24,6 +24,7 @@ ybm backup delete [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_backup_describe.md
+++ b/docs/ybm_backup_describe.md
@@ -23,6 +23,7 @@ ybm backup describe [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_backup_list.md
+++ b/docs/ybm_backup_list.md
@@ -23,6 +23,7 @@ ybm backup list [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_backup_policy.md
+++ b/docs/ybm_backup_policy.md
@@ -22,6 +22,7 @@ ybm backup policy [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_backup_policy_disable.md
+++ b/docs/ybm_backup_policy_disable.md
@@ -23,6 +23,7 @@ ybm backup policy disable [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_backup_policy_enable.md
+++ b/docs/ybm_backup_policy_enable.md
@@ -23,6 +23,7 @@ ybm backup policy enable [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_backup_policy_list.md
+++ b/docs/ybm_backup_policy_list.md
@@ -23,6 +23,7 @@ ybm backup policy list [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_backup_policy_update.md
+++ b/docs/ybm_backup_policy_update.md
@@ -28,6 +28,7 @@ ybm backup policy update [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_backup_restore.md
+++ b/docs/ybm_backup_restore.md
@@ -24,6 +24,7 @@ ybm backup restore [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_cluster.md
+++ b/docs/ybm_cluster.md
@@ -22,6 +22,7 @@ ybm cluster [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table
@@ -38,9 +39,11 @@ ybm cluster [flags]
 * [ybm cluster describe](ybm_cluster_describe.md)	 - Describe a cluster
 * [ybm cluster encryption](ybm_cluster_encryption.md)	 - Manage Encryption at Rest (EaR) for a cluster
 * [ybm cluster list](ybm_cluster_list.md)	 - List clusters
+* [ybm cluster namespace](ybm_cluster_namespace.md)	 - Manage Cluster Namespaces
 * [ybm cluster network](ybm_cluster_network.md)	 - Manage network operations
 * [ybm cluster node](ybm_cluster_node.md)	 - Manage nodes for a cluster
 * [ybm cluster pause](ybm_cluster_pause.md)	 - Pause a cluster
+* [ybm cluster pitr-config](ybm_cluster_pitr-config.md)	 - Manage Cluster PITR Configs
 * [ybm cluster read-replica](ybm_cluster_read-replica.md)	 - Manage Read Replicas
 * [ybm cluster resume](ybm_cluster_resume.md)	 - Resume a cluster
 * [ybm cluster update](ybm_cluster_update.md)	 - Update a cluster

--- a/docs/ybm_cluster_cert.md
+++ b/docs/ybm_cluster_cert.md
@@ -22,6 +22,7 @@ ybm cluster cert [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_cluster_cert_download.md
+++ b/docs/ybm_cluster_cert_download.md
@@ -24,6 +24,7 @@ ybm cluster cert download [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_cluster_create.md
+++ b/docs/ybm_cluster_create.md
@@ -43,6 +43,7 @@ ybm cluster create [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_cluster_delete.md
+++ b/docs/ybm_cluster_delete.md
@@ -24,6 +24,7 @@ ybm cluster delete [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_cluster_describe.md
+++ b/docs/ybm_cluster_describe.md
@@ -23,6 +23,7 @@ ybm cluster describe [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_cluster_encryption.md
+++ b/docs/ybm_cluster_encryption.md
@@ -23,6 +23,7 @@ ybm cluster encryption [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_cluster_encryption_list.md
+++ b/docs/ybm_cluster_encryption_list.md
@@ -23,6 +23,7 @@ ybm cluster encryption list [flags]
   -c, --cluster-name string   [REQUIRED] The name of the cluster.
       --config string         config file (default is $HOME/.ybm-cli.yaml)
       --debug                 Use debug mode, same as --logLevel debug
+      --host string           YugabyteDB Aeon Api hostname
   -l, --logLevel string       Select the desired log level format(info). Default to info
       --no-color              Disable colors in output , default to false
   -o, --output string         Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_cluster_encryption_update-state.md
+++ b/docs/ybm_cluster_encryption_update-state.md
@@ -25,6 +25,7 @@ ybm cluster encryption update-state [flags]
   -c, --cluster-name string   [REQUIRED] The name of the cluster.
       --config string         config file (default is $HOME/.ybm-cli.yaml)
       --debug                 Use debug mode, same as --logLevel debug
+      --host string           YugabyteDB Aeon Api hostname
   -l, --logLevel string       Select the desired log level format(info). Default to info
       --no-color              Disable colors in output , default to false
   -o, --output string         Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_cluster_encryption_update.md
+++ b/docs/ybm_cluster_encryption_update.md
@@ -33,6 +33,7 @@ ybm cluster encryption update [flags]
   -c, --cluster-name string   [REQUIRED] The name of the cluster.
       --config string         config file (default is $HOME/.ybm-cli.yaml)
       --debug                 Use debug mode, same as --logLevel debug
+      --host string           YugabyteDB Aeon Api hostname
   -l, --logLevel string       Select the desired log level format(info). Default to info
       --no-color              Disable colors in output , default to false
   -o, --output string         Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_cluster_list.md
+++ b/docs/ybm_cluster_list.md
@@ -22,6 +22,7 @@ ybm cluster list [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_cluster_namespace.md
+++ b/docs/ybm_cluster_namespace.md
@@ -1,0 +1,38 @@
+## ybm cluster namespace
+
+Manage Cluster Namespaces
+
+### Synopsis
+
+Manage Cluster namespaces
+
+```
+ybm cluster namespace [flags]
+```
+
+### Options
+
+```
+  -c, --cluster-name string   [REQUIRED] The name of the cluster.
+  -h, --help                  help for namespace
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string      YugabyteDB Aeon account API key
+      --config string      config file (default is $HOME/.ybm-cli.yaml)
+      --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
+  -l, --logLevel string    Select the desired log level format(info). Default to info
+      --no-color           Disable colors in output , default to false
+  -o, --output string      Select the desired output format (table, json, pretty). Default to table
+      --timeout duration   Wait command timeout, example: 5m, 1h. (default 168h0m0s)
+      --wait               Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm cluster](ybm_cluster.md)	 - Manage cluster operations
+* [ybm cluster namespace list](ybm_cluster_namespace_list.md)	 - List namespaces for a cluster
+

--- a/docs/ybm_cluster_namespace_list.md
+++ b/docs/ybm_cluster_namespace_list.md
@@ -1,0 +1,37 @@
+## ybm cluster namespace list
+
+List namespaces for a cluster
+
+### Synopsis
+
+List namespaces on your YugabyteDB Aeon cluster
+
+```
+ybm cluster namespace list [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for list
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string         YugabyteDB Aeon account API key
+  -c, --cluster-name string   [REQUIRED] The name of the cluster.
+      --config string         config file (default is $HOME/.ybm-cli.yaml)
+      --debug                 Use debug mode, same as --logLevel debug
+      --host string           YugabyteDB Aeon Api hostname
+  -l, --logLevel string       Select the desired log level format(info). Default to info
+      --no-color              Disable colors in output , default to false
+  -o, --output string         Select the desired output format (table, json, pretty). Default to table
+      --timeout duration      Wait command timeout, example: 5m, 1h. (default 168h0m0s)
+      --wait                  Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm cluster namespace](ybm_cluster_namespace.md)	 - Manage Cluster Namespaces
+

--- a/docs/ybm_cluster_network.md
+++ b/docs/ybm_cluster_network.md
@@ -23,6 +23,7 @@ ybm cluster network [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_cluster_network_allow-list.md
+++ b/docs/ybm_cluster_network_allow-list.md
@@ -23,6 +23,7 @@ ybm cluster network allow-list [flags]
   -c, --cluster-name string   [REQUIRED] The name of the cluster.
       --config string         config file (default is $HOME/.ybm-cli.yaml)
       --debug                 Use debug mode, same as --logLevel debug
+      --host string           YugabyteDB Aeon Api hostname
   -l, --logLevel string       Select the desired log level format(info). Default to info
       --no-color              Disable colors in output , default to false
   -o, --output string         Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_cluster_network_allow-list_assign.md
+++ b/docs/ybm_cluster_network_allow-list_assign.md
@@ -24,6 +24,7 @@ ybm cluster network allow-list assign [flags]
   -c, --cluster-name string   [REQUIRED] The name of the cluster.
       --config string         config file (default is $HOME/.ybm-cli.yaml)
       --debug                 Use debug mode, same as --logLevel debug
+      --host string           YugabyteDB Aeon Api hostname
   -l, --logLevel string       Select the desired log level format(info). Default to info
       --no-color              Disable colors in output , default to false
   -o, --output string         Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_cluster_network_allow-list_unassign.md
+++ b/docs/ybm_cluster_network_allow-list_unassign.md
@@ -24,6 +24,7 @@ ybm cluster network allow-list unassign [flags]
   -c, --cluster-name string   [REQUIRED] The name of the cluster.
       --config string         config file (default is $HOME/.ybm-cli.yaml)
       --debug                 Use debug mode, same as --logLevel debug
+      --host string           YugabyteDB Aeon Api hostname
   -l, --logLevel string       Select the desired log level format(info). Default to info
       --no-color              Disable colors in output , default to false
   -o, --output string         Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_cluster_network_endpoint.md
+++ b/docs/ybm_cluster_network_endpoint.md
@@ -23,6 +23,7 @@ ybm cluster network endpoint [flags]
   -c, --cluster-name string   [REQUIRED] The name of the cluster.
       --config string         config file (default is $HOME/.ybm-cli.yaml)
       --debug                 Use debug mode, same as --logLevel debug
+      --host string           YugabyteDB Aeon Api hostname
   -l, --logLevel string       Select the desired log level format(info). Default to info
       --no-color              Disable colors in output , default to false
   -o, --output string         Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_cluster_network_endpoint_create.md
+++ b/docs/ybm_cluster_network_endpoint_create.md
@@ -26,6 +26,7 @@ ybm cluster network endpoint create [flags]
   -c, --cluster-name string   [REQUIRED] The name of the cluster.
       --config string         config file (default is $HOME/.ybm-cli.yaml)
       --debug                 Use debug mode, same as --logLevel debug
+      --host string           YugabyteDB Aeon Api hostname
   -l, --logLevel string       Select the desired log level format(info). Default to info
       --no-color              Disable colors in output , default to false
   -o, --output string         Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_cluster_network_endpoint_delete.md
+++ b/docs/ybm_cluster_network_endpoint_delete.md
@@ -25,6 +25,7 @@ ybm cluster network endpoint delete [flags]
   -c, --cluster-name string   [REQUIRED] The name of the cluster.
       --config string         config file (default is $HOME/.ybm-cli.yaml)
       --debug                 Use debug mode, same as --logLevel debug
+      --host string           YugabyteDB Aeon Api hostname
   -l, --logLevel string       Select the desired log level format(info). Default to info
       --no-color              Disable colors in output , default to false
   -o, --output string         Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_cluster_network_endpoint_describe.md
+++ b/docs/ybm_cluster_network_endpoint_describe.md
@@ -24,6 +24,7 @@ ybm cluster network endpoint describe [flags]
   -c, --cluster-name string   [REQUIRED] The name of the cluster.
       --config string         config file (default is $HOME/.ybm-cli.yaml)
       --debug                 Use debug mode, same as --logLevel debug
+      --host string           YugabyteDB Aeon Api hostname
   -l, --logLevel string       Select the desired log level format(info). Default to info
       --no-color              Disable colors in output , default to false
   -o, --output string         Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_cluster_network_endpoint_list.md
+++ b/docs/ybm_cluster_network_endpoint_list.md
@@ -25,6 +25,7 @@ ybm cluster network endpoint list [flags]
   -c, --cluster-name string   [REQUIRED] The name of the cluster.
       --config string         config file (default is $HOME/.ybm-cli.yaml)
       --debug                 Use debug mode, same as --logLevel debug
+      --host string           YugabyteDB Aeon Api hostname
   -l, --logLevel string       Select the desired log level format(info). Default to info
       --no-color              Disable colors in output , default to false
   -o, --output string         Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_cluster_network_endpoint_update.md
+++ b/docs/ybm_cluster_network_endpoint_update.md
@@ -25,6 +25,7 @@ ybm cluster network endpoint update [flags]
   -c, --cluster-name string   [REQUIRED] The name of the cluster.
       --config string         config file (default is $HOME/.ybm-cli.yaml)
       --debug                 Use debug mode, same as --logLevel debug
+      --host string           YugabyteDB Aeon Api hostname
   -l, --logLevel string       Select the desired log level format(info). Default to info
       --no-color              Disable colors in output , default to false
   -o, --output string         Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_cluster_node.md
+++ b/docs/ybm_cluster_node.md
@@ -23,6 +23,7 @@ ybm cluster node [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_cluster_node_list.md
+++ b/docs/ybm_cluster_node_list.md
@@ -23,6 +23,7 @@ ybm cluster node list [flags]
   -c, --cluster-name string   [REQUIRED] The name of the cluster.
       --config string         config file (default is $HOME/.ybm-cli.yaml)
       --debug                 Use debug mode, same as --logLevel debug
+      --host string           YugabyteDB Aeon Api hostname
   -l, --logLevel string       Select the desired log level format(info). Default to info
       --no-color              Disable colors in output , default to false
   -o, --output string         Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_cluster_pause.md
+++ b/docs/ybm_cluster_pause.md
@@ -23,6 +23,7 @@ ybm cluster pause [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_cluster_pitr-config.md
+++ b/docs/ybm_cluster_pitr-config.md
@@ -1,0 +1,37 @@
+## ybm cluster pitr-config
+
+Manage Cluster PITR Configs
+
+### Synopsis
+
+Manage Cluster PITR Configs
+
+```
+ybm cluster pitr-config [flags]
+```
+
+### Options
+
+```
+  -c, --cluster-name string   [REQUIRED] The name of the cluster.
+  -h, --help                  help for pitr-config
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --apiKey string      YugabyteDB Aeon account API key
+      --config string      config file (default is $HOME/.ybm-cli.yaml)
+      --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
+  -l, --logLevel string    Select the desired log level format(info). Default to info
+      --no-color           Disable colors in output , default to false
+  -o, --output string      Select the desired output format (table, json, pretty). Default to table
+      --timeout duration   Wait command timeout, example: 5m, 1h. (default 168h0m0s)
+      --wait               Wait until the task is completed, otherwise it will exit immediately, default to false
+```
+
+### SEE ALSO
+
+* [ybm cluster](ybm_cluster.md)	 - Manage cluster operations
+

--- a/docs/ybm_cluster_read-replica.md
+++ b/docs/ybm_cluster_read-replica.md
@@ -23,6 +23,7 @@ ybm cluster read-replica [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_cluster_read-replica_create.md
+++ b/docs/ybm_cluster_read-replica_create.md
@@ -24,6 +24,7 @@ ybm cluster read-replica create [flags]
   -c, --cluster-name string   [REQUIRED] The name of the cluster.
       --config string         config file (default is $HOME/.ybm-cli.yaml)
       --debug                 Use debug mode, same as --logLevel debug
+      --host string           YugabyteDB Aeon Api hostname
   -l, --logLevel string       Select the desired log level format(info). Default to info
       --no-color              Disable colors in output , default to false
   -o, --output string         Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_cluster_read-replica_delete.md
+++ b/docs/ybm_cluster_read-replica_delete.md
@@ -24,6 +24,7 @@ ybm cluster read-replica delete [flags]
   -c, --cluster-name string   [REQUIRED] The name of the cluster.
       --config string         config file (default is $HOME/.ybm-cli.yaml)
       --debug                 Use debug mode, same as --logLevel debug
+      --host string           YugabyteDB Aeon Api hostname
   -l, --logLevel string       Select the desired log level format(info). Default to info
       --no-color              Disable colors in output , default to false
   -o, --output string         Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_cluster_read-replica_list.md
+++ b/docs/ybm_cluster_read-replica_list.md
@@ -23,6 +23,7 @@ ybm cluster read-replica list [flags]
   -c, --cluster-name string   [REQUIRED] The name of the cluster.
       --config string         config file (default is $HOME/.ybm-cli.yaml)
       --debug                 Use debug mode, same as --logLevel debug
+      --host string           YugabyteDB Aeon Api hostname
   -l, --logLevel string       Select the desired log level format(info). Default to info
       --no-color              Disable colors in output , default to false
   -o, --output string         Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_cluster_read-replica_update.md
+++ b/docs/ybm_cluster_read-replica_update.md
@@ -24,6 +24,7 @@ ybm cluster read-replica update [flags]
   -c, --cluster-name string   [REQUIRED] The name of the cluster.
       --config string         config file (default is $HOME/.ybm-cli.yaml)
       --debug                 Use debug mode, same as --logLevel debug
+      --host string           YugabyteDB Aeon Api hostname
   -l, --logLevel string       Select the desired log level format(info). Default to info
       --no-color              Disable colors in output , default to false
   -o, --output string         Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_cluster_resume.md
+++ b/docs/ybm_cluster_resume.md
@@ -23,6 +23,7 @@ ybm cluster resume [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_cluster_update.md
+++ b/docs/ybm_cluster_update.md
@@ -30,6 +30,7 @@ ybm cluster update [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_completion.md
+++ b/docs/ybm_completion.md
@@ -20,6 +20,7 @@ See each sub-command's help for details on how to use the generated script.
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_completion_bash.md
+++ b/docs/ybm_completion_bash.md
@@ -43,6 +43,7 @@ ybm completion bash
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_completion_fish.md
+++ b/docs/ybm_completion_fish.md
@@ -34,6 +34,7 @@ ybm completion fish [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_completion_powershell.md
+++ b/docs/ybm_completion_powershell.md
@@ -31,6 +31,7 @@ ybm completion powershell [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_completion_zsh.md
+++ b/docs/ybm_completion_zsh.md
@@ -45,6 +45,7 @@ ybm completion zsh [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_integration.md
+++ b/docs/ybm_integration.md
@@ -22,6 +22,7 @@ ybm integration [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_integration_create.md
+++ b/docs/ybm_integration_create.md
@@ -13,18 +13,20 @@ ybm integration create [flags]
 ### Options
 
 ```
-      --config-name string              [REQUIRED] The name of the Integration
-      --type string                     [REQUIRED] The type of third party Integration sink
-      --datadog-spec stringToString     Configuration for Datadog. 
-                                        	Please provide key value pairs as follows: 
-                                        	api-key=<your-datadog-api-key>,site=<your-datadog-site-parameters> (default [])
-      --grafana-spec stringToString     Configuration for Grafana. 
-                                        	Please provide key value pairs as follows: 
-                                        	access-policy-token=<your-grafana-token>,zone=<your-grafana-zone-parameter>,instance-id=<your-grafana-instance-id>,org-slug=<your-grafana-org-slug> (default [])
-      --sumologic-spec stringToString   Configuration for sumologic. 
-                                        	Please provide key value pairs as follows: 
-                                        	access-key=<your-sumologic-access-key>,access-id=<your-sumologic-access-id>,installation-token=<your-sumologic-installation-token> (default [])
-  -h, --help                            help for create
+      --config-name string                 [REQUIRED] The name of the Integration
+      --type string                        [REQUIRED] The type of third party Integration sink
+      --datadog-spec stringToString        Configuration for Datadog. 
+                                           	Please provide key value pairs as follows: 
+                                           	api-key=<your-datadog-api-key>,site=<your-datadog-site-parameters> (default [])
+      --grafana-spec stringToString        Configuration for Grafana. 
+                                           	Please provide key value pairs as follows: 
+                                           	access-policy-token=<your-grafana-token>,zone=<your-grafana-zone-parameter>,instance-id=<your-grafana-instance-id>,org-slug=<your-grafana-org-slug> (default [])
+      --sumologic-spec stringToString      Configuration for sumologic. 
+                                           	Please provide key value pairs as follows: 
+                                           	access-key=<your-sumologic-access-key>,access-id=<your-sumologic-access-id>,installation-token=<your-sumologic-installation-token> (default [])
+      --googlecloud-cred-filepath string   Filepath for Google Cloud service account credentials. 
+                                           	Please provide absolute file path
+  -h, --help                               help for create
 ```
 
 ### Options inherited from parent commands
@@ -33,6 +35,7 @@ ybm integration create [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_integration_delete.md
+++ b/docs/ybm_integration_delete.md
@@ -24,6 +24,7 @@ ybm integration delete [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_integration_list.md
+++ b/docs/ybm_integration_list.md
@@ -22,6 +22,7 @@ ybm integration list [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_metrics-exporter.md
+++ b/docs/ybm_metrics-exporter.md
@@ -22,6 +22,7 @@ ybm metrics-exporter [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_metrics-exporter_assign.md
+++ b/docs/ybm_metrics-exporter_assign.md
@@ -24,6 +24,7 @@ ybm metrics-exporter assign [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_metrics-exporter_create.md
+++ b/docs/ybm_metrics-exporter_create.md
@@ -33,6 +33,7 @@ ybm metrics-exporter create [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_metrics-exporter_delete.md
+++ b/docs/ybm_metrics-exporter_delete.md
@@ -24,6 +24,7 @@ ybm metrics-exporter delete [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_metrics-exporter_describe.md
+++ b/docs/ybm_metrics-exporter_describe.md
@@ -23,6 +23,7 @@ ybm metrics-exporter describe [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_metrics-exporter_list.md
+++ b/docs/ybm_metrics-exporter_list.md
@@ -22,6 +22,7 @@ ybm metrics-exporter list [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_metrics-exporter_pause.md
+++ b/docs/ybm_metrics-exporter_pause.md
@@ -23,6 +23,7 @@ ybm metrics-exporter pause [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_metrics-exporter_unassign.md
+++ b/docs/ybm_metrics-exporter_unassign.md
@@ -23,6 +23,7 @@ ybm metrics-exporter unassign [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_metrics-exporter_update.md
+++ b/docs/ybm_metrics-exporter_update.md
@@ -34,6 +34,7 @@ ybm metrics-exporter update [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_network-allow-list.md
+++ b/docs/ybm_network-allow-list.md
@@ -22,6 +22,7 @@ ybm network-allow-list [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_network-allow-list_create.md
+++ b/docs/ybm_network-allow-list_create.md
@@ -25,6 +25,7 @@ ybm network-allow-list create [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_network-allow-list_delete.md
+++ b/docs/ybm_network-allow-list_delete.md
@@ -24,6 +24,7 @@ ybm network-allow-list delete [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_network-allow-list_list.md
+++ b/docs/ybm_network-allow-list_list.md
@@ -23,6 +23,7 @@ ybm network-allow-list list [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_permission.md
+++ b/docs/ybm_permission.md
@@ -22,6 +22,7 @@ ybm permission [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_permission_list.md
+++ b/docs/ybm_permission_list.md
@@ -22,6 +22,7 @@ ybm permission list [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_region.md
+++ b/docs/ybm_region.md
@@ -22,6 +22,7 @@ ybm region [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_region_instance.md
+++ b/docs/ybm_region_instance.md
@@ -22,6 +22,7 @@ ybm region instance [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_region_instance_list.md
+++ b/docs/ybm_region_instance_list.md
@@ -26,6 +26,7 @@ ybm region instance list [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_region_list.md
+++ b/docs/ybm_region_list.md
@@ -23,6 +23,7 @@ ybm region list [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_role.md
+++ b/docs/ybm_role.md
@@ -22,6 +22,7 @@ ybm role [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_role_create.md
+++ b/docs/ybm_role_create.md
@@ -26,6 +26,7 @@ ybm role create [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_role_delete.md
+++ b/docs/ybm_role_delete.md
@@ -24,6 +24,7 @@ ybm role delete [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_role_describe.md
+++ b/docs/ybm_role_describe.md
@@ -23,6 +23,7 @@ ybm role describe [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_role_list.md
+++ b/docs/ybm_role_list.md
@@ -24,6 +24,7 @@ ybm role list [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_role_update.md
+++ b/docs/ybm_role_update.md
@@ -27,6 +27,7 @@ ybm role update [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_signup.md
+++ b/docs/ybm_signup.md
@@ -22,6 +22,7 @@ ybm signup [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_usage.md
+++ b/docs/ybm_usage.md
@@ -22,6 +22,7 @@ ybm usage [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_usage_get.md
+++ b/docs/ybm_usage_get.md
@@ -28,6 +28,7 @@ ybm usage get [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_user.md
+++ b/docs/ybm_user.md
@@ -22,6 +22,7 @@ ybm user [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_user_delete.md
+++ b/docs/ybm_user_delete.md
@@ -24,6 +24,7 @@ ybm user delete [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_user_invite.md
+++ b/docs/ybm_user_invite.md
@@ -25,6 +25,7 @@ ybm user invite [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_user_list.md
+++ b/docs/ybm_user_list.md
@@ -23,6 +23,7 @@ ybm user list [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_user_update.md
+++ b/docs/ybm_user_update.md
@@ -25,6 +25,7 @@ ybm user update [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_vpc.md
+++ b/docs/ybm_vpc.md
@@ -22,6 +22,7 @@ ybm vpc [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_vpc_create.md
+++ b/docs/ybm_vpc_create.md
@@ -27,6 +27,7 @@ ybm vpc create [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_vpc_delete.md
+++ b/docs/ybm_vpc_delete.md
@@ -24,6 +24,7 @@ ybm vpc delete [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_vpc_list.md
+++ b/docs/ybm_vpc_list.md
@@ -23,6 +23,7 @@ ybm vpc list [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_vpc_peering.md
+++ b/docs/ybm_vpc_peering.md
@@ -22,6 +22,7 @@ ybm vpc peering [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_vpc_peering_create.md
+++ b/docs/ybm_vpc_peering_create.md
@@ -31,6 +31,7 @@ ybm vpc peering create [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_vpc_peering_delete.md
+++ b/docs/ybm_vpc_peering_delete.md
@@ -24,6 +24,7 @@ ybm vpc peering delete [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/docs/ybm_vpc_peering_list.md
+++ b/docs/ybm_vpc_peering_list.md
@@ -23,6 +23,7 @@ ybm vpc peering list [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.17.0
 	github.com/t-tomalak/logrus-easy-formatter v0.0.0-20190827215021-c074f06c5816
-	github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20240726075817-6a77649f9d1f
+	github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20240802115126-ab96cea435fc
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9
 	golang.org/x/mod v0.14.0
 	golang.org/x/term v0.16.0

--- a/go.sum
+++ b/go.sum
@@ -288,6 +288,8 @@ github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20240716132321-
 github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20240716132321-46d87b66474f/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
 github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20240726075817-6a77649f9d1f h1:NL8BNehwmk7UgXnCWhwPS9elnEoUvutBpgcNQbj9PUo=
 github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20240726075817-6a77649f9d1f/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20240802115126-ab96cea435fc h1:QJZQS0sq9rZCirBG3FITXxCBHwRjkdqeKQmXLZ/fSH4=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20240802115126-ab96cea435fc/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/internal/formatter/clusters.go
+++ b/internal/formatter/clusters.go
@@ -138,13 +138,13 @@ func (c *ClusterContext) HealthState() string {
 
 func (c *ClusterContext) NodesSpec() string {
 	iops := "-"
-	if c.c.GetSpec().ClusterInfo.NodeInfo.DiskIops.Get() != nil {
-		iops = strconv.Itoa(int(*c.c.GetSpec().ClusterInfo.NodeInfo.DiskIops.Get()))
+	if c.c.GetSpec().ClusterInfo.NodeInfo.Get().DiskIops.Get() != nil {
+		iops = strconv.Itoa(int(*c.c.GetSpec().ClusterInfo.NodeInfo.Get().DiskIops.Get()))
 	}
 	return fmt.Sprintf("%d / %s / %dGB / %s",
-		c.c.GetSpec().ClusterInfo.NodeInfo.NumCores,
-		convertMbtoGb(c.c.GetSpec().ClusterInfo.NodeInfo.MemoryMb),
-		c.c.GetSpec().ClusterInfo.NodeInfo.DiskSizeGb,
+		c.c.GetSpec().ClusterInfo.NodeInfo.Get().NumCores,
+		convertMbtoGb(c.c.GetSpec().ClusterInfo.NodeInfo.Get().MemoryMb),
+		c.c.GetSpec().ClusterInfo.NodeInfo.Get().DiskSizeGb,
 		iops)
 }
 

--- a/internal/formatter/clusters_full.go
+++ b/internal/formatter/clusters_full.go
@@ -297,32 +297,32 @@ func (c *clusterInfoRegionsContext) NumNode() string {
 }
 
 func (c *clusterInfoRegionsContext) NumCores() string {
-    numCores := c.clusterInfo.NodeInfo.NumCores
-    if c.clusterInfoRegion.NodeInfo.IsSet() {
-        if nc, ok := c.clusterInfoRegion.NodeInfo.Get().GetNumCoresOk(); ok {
-            numCores = *nc
-        }
-    }
+	numCores := c.clusterInfo.NodeInfo.Get().NumCores
+	if c.clusterInfoRegion.NodeInfo.IsSet() {
+		if nc, ok := c.clusterInfoRegion.NodeInfo.Get().GetNumCoresOk(); ok {
+			numCores = *nc
+		}
+	}
 	return fmt.Sprintf("%d", numCores)
 }
 
 func (c *clusterInfoRegionsContext) MemoryGb() string {
-    memoryMb := c.clusterInfo.NodeInfo.MemoryMb
-    if c.clusterInfoRegion.NodeInfo.IsSet() {
-        if mem, ok := c.clusterInfoRegion.NodeInfo.Get().GetMemoryMbOk(); ok {
-            memoryMb = *mem
-        }
-    }
+	memoryMb := c.clusterInfo.NodeInfo.Get().MemoryMb
+	if c.clusterInfoRegion.NodeInfo.IsSet() {
+		if mem, ok := c.clusterInfoRegion.NodeInfo.Get().GetMemoryMbOk(); ok {
+			memoryMb = *mem
+		}
+	}
 	return convertMbtoGb(memoryMb)
 }
 
 func (c *clusterInfoRegionsContext) DiskSizeGb() string {
-    diskSizeGb := c.clusterInfo.NodeInfo.DiskSizeGb
-    if c.clusterInfoRegion.NodeInfo.IsSet() {
-        if ds, ok := c.clusterInfoRegion.NodeInfo.Get().GetDiskSizeGbOk(); ok {
-            diskSizeGb = *ds
-        }
-    }
+	diskSizeGb := c.clusterInfo.NodeInfo.Get().DiskSizeGb
+	if c.clusterInfoRegion.NodeInfo.IsSet() {
+		if ds, ok := c.clusterInfoRegion.NodeInfo.Get().GetDiskSizeGbOk(); ok {
+			diskSizeGb = *ds
+		}
+	}
 	return fmt.Sprintf("%dGB", diskSizeGb)
 }
 

--- a/internal/formatter/db_audit_logs_exporter.go
+++ b/internal/formatter/db_audit_logs_exporter.go
@@ -63,12 +63,12 @@ func DbAuditLogsExporterWrite(ctx Context, dbAuditLogsExporterConfigs []ybmclien
 func NewDbAuditLogsExporterContext() *DbAuditLogsExporterContext {
 	dbAuditLogsExporterCtx := DbAuditLogsExporterContext{}
 	dbAuditLogsExporterCtx.Header = SubHeaderContext{
-		"YsqlConfig":          ysqlConfigHeader,
-		"ID":                  "ID",
-		"State":               stateHeader,
-		"IntegrationId":       integrationIdHeader,
-		"ClusterId":           clusterIdHeader,
-		"CreatedAt":           dateCreatedAtHeader,
+		"YsqlConfig":    ysqlConfigHeader,
+		"ID":            "ID",
+		"State":         stateHeader,
+		"IntegrationId": integrationIdHeader,
+		"ClusterId":     clusterIdHeader,
+		"CreatedAt":     dateCreatedAtHeader,
 	}
 	return &dbAuditLogsExporterCtx
 }

--- a/internal/formatter/namespaces.go
+++ b/internal/formatter/namespaces.go
@@ -1,0 +1,92 @@
+// Licensed to Yugabyte, Inc. under one or more contributor license
+// agreements. See the NOTICE file distributed with this work for
+// additional information regarding copyright ownership. Yugabyte
+// licenses this file to you under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package formatter
+
+import (
+	"encoding/json"
+	"sort"
+
+	"github.com/sirupsen/logrus"
+	ybmclient "github.com/yugabyte/yugabytedb-managed-go-client-internal"
+)
+
+const (
+	defaultNamespaceListing = "table {{.Namespace}}\t{{.TableType}}"
+	namespaceHeader         = "Namespace"
+	tableTypeHeader         = "Table Type"
+)
+
+type NamespaceContext struct {
+	HeaderContext
+	Context
+	n ybmclient.ClusterNamespaceData
+}
+
+func NewNamespaceFormat(source string) Format {
+	switch source {
+	case "table", "":
+		format := defaultNamespaceListing
+		return Format(format)
+	default: // custom format or json or pretty
+		return Format(source)
+	}
+}
+
+func NamespaceWrite(ctx Context, namespace []ybmclient.ClusterNamespaceData) error {
+	//Sort by name
+	sort.Slice(namespace, func(i, j int) bool {
+		return string(namespace[i].Name) < string(namespace[j].Name)
+	})
+
+	render := func(format func(subContext SubContext) error) error {
+		for _, namespace := range namespace {
+			if namespace.GetTableType() == "REDIS_TABLE_TYPE" || namespace.GetTableType() == "TRANSACTION_STATUS_TABLE_TYPE" {
+				continue
+			}
+			err := format(&NamespaceContext{n: namespace})
+			if err != nil {
+				logrus.Debugf("Error rendering namespace: %v", err)
+				return err
+			}
+		}
+		return nil
+	}
+	return ctx.Write(NewNamespaceContext(), render)
+}
+
+func NewNamespaceContext() *NamespaceContext {
+	namespaceCtx := NamespaceContext{}
+	namespaceCtx.Header = SubHeaderContext{
+		"Namespace": namespaceHeader,
+		"TableType": tableTypeHeader,
+	}
+	return &namespaceCtx
+}
+
+func (n *NamespaceContext) Namespace() string {
+	return n.n.GetName()
+}
+
+func (n *NamespaceContext) TableType() string {
+	if n.n.GetTableType() == "PGSQL_TABLE_TYPE" {
+		return "YSQL"
+	}
+	return "YCQL"
+}
+
+func (n *NamespaceContext) MarshalJSON() ([]byte, error) {
+	return json.Marshal(n.n)
+}

--- a/internal/formatter/pitr_configs.go
+++ b/internal/formatter/pitr_configs.go
@@ -1,0 +1,118 @@
+// Licensed to Yugabyte, Inc. under one or more contributor license
+// agreements. See the NOTICE file distributed with this work for
+// additional information regarding copyright ownership. Yugabyte
+// licenses this file to you under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package formatter
+
+import (
+	"encoding/json"
+	"sort"
+
+	"github.com/sirupsen/logrus"
+	ybmclient "github.com/yugabyte/yugabytedb-managed-go-client-internal"
+)
+
+const (
+	defaultPitrConfigListing      = "table {{.Namespace}}\t{{.TableType}}\t{{.RetentionPeriodInDays}}\t{{.BackupIntervalInSeconds}}\t{{.State}}\t{{.CreatedAt}}"
+	retentionPeriodInDaysHeader   = "Retention Period in Days"
+	backupIntervalInSecondsHeader = "Backup Interval in Seconds"
+)
+
+type PitrConfigContext struct {
+	HeaderContext
+	Context
+	d ybmclient.DatabasePitrConfigData
+}
+
+func NewPitrConfigFormat(source string) Format {
+	switch source {
+	case "table", "":
+		format := defaultPitrConfigListing
+		return Format(format)
+	default: // custom format or json or pretty
+		return Format(source)
+	}
+}
+
+func SinglePitrConfigWrite(ctx Context, pitrConfig ybmclient.DatabasePitrConfigData) error {
+	render := func(format func(subContext SubContext) error) error {
+		err := format(&PitrConfigContext{d: pitrConfig})
+		if err != nil {
+			logrus.Debugf("Error rendering PITR Config: %v", err)
+			return err
+		}
+		return nil
+	}
+	return ctx.Write(NewPitrConfigContext(), render)
+}
+
+func PitrConfigWrite(ctx Context, pitrConfig []ybmclient.DatabasePitrConfigData) error {
+	//Sort by database name
+	sort.Slice(pitrConfig, func(i, j int) bool {
+		return string(pitrConfig[i].Spec.DatabaseName) < string(pitrConfig[j].Spec.DatabaseName)
+	})
+
+	render := func(format func(subContext SubContext) error) error {
+		for _, pitrConfig := range pitrConfig {
+			err := format(&PitrConfigContext{d: pitrConfig})
+			if err != nil {
+				logrus.Debugf("Error rendering PITR Config: %v", err)
+				return err
+			}
+		}
+		return nil
+	}
+	return ctx.Write(NewPitrConfigContext(), render)
+}
+
+func NewPitrConfigContext() *PitrConfigContext {
+	pitrConfigCtx := PitrConfigContext{}
+	pitrConfigCtx.Header = SubHeaderContext{
+		"Namespace":               namespaceHeader,
+		"TableType":               tableTypeHeader,
+		"RetentionPeriodInDays":   retentionPeriodInDaysHeader,
+		"BackupIntervalInSeconds": backupIntervalInSecondsHeader,
+		"State":                   stateHeader,
+		"CreatedAt":               createdAtHeader,
+	}
+	return &pitrConfigCtx
+}
+
+func (d *PitrConfigContext) Namespace() string {
+	return d.d.Spec.DatabaseName
+}
+
+func (d *PitrConfigContext) TableType() string {
+	return string(d.d.Spec.DatabaseType)
+}
+
+func (d *PitrConfigContext) RetentionPeriodInDays() int32 {
+	return d.d.Spec.RetentionPeriod
+}
+
+func (d *PitrConfigContext) BackupIntervalInSeconds() int32 {
+	return d.d.Info.GetBackupInterval()
+}
+
+func (d *PitrConfigContext) State() string {
+	return string(d.d.Info.GetState())
+}
+
+func (d *PitrConfigContext) CreatedAt() string {
+	return d.d.Info.Metadata.Get().GetCreatedOn()
+}
+
+func (d *PitrConfigContext) MarshalJSON() ([]byte, error) {
+	return json.Marshal(d.d)
+}

--- a/internal/formatter/read_replica.go
+++ b/internal/formatter/read_replica.go
@@ -98,13 +98,13 @@ func (c *ReadReplicaContext) Endpoint() string {
 
 func (c *ReadReplicaContext) NodesSpec() string {
 	iops := "-"
-	if c.rrSpec.NodeInfo.DiskIops.Get() != nil {
-		iops = strconv.Itoa(int(*c.rrSpec.NodeInfo.DiskIops.Get()))
+	if c.rrSpec.NodeInfo.Get().DiskIops.Get() != nil {
+		iops = strconv.Itoa(int(*c.rrSpec.NodeInfo.Get().DiskIops.Get()))
 	}
 	return fmt.Sprintf("%d / %s / %dGB / %s",
-		c.rrSpec.NodeInfo.NumCores,
-		convertMbtoGb(c.rrSpec.NodeInfo.MemoryMb),
-		c.rrSpec.NodeInfo.DiskSizeGb,
+		c.rrSpec.NodeInfo.Get().NumCores,
+		convertMbtoGb(c.rrSpec.NodeInfo.Get().MemoryMb),
+		c.rrSpec.NodeInfo.Get().DiskSizeGb,
 		iops)
 }
 


### PR DESCRIPTION
Design doc: https://docs.google.com/document/d/18Dzi7yJOPbnLwlxghonkMhVqt7aTrSIJ0qXmgsNWTqA/edit?usp=sharing

This PR adds support for:
1. Listing cluster namespaces
2. Creating PITR Config for a cluster namespace
3. Listing cluster PITR Configs
4. Restoring a cluster namespace to a point via PITR Config

<img width="1448" alt="Screenshot 2024-08-08 at 10 20 48 AM" src="https://github.com/user-attachments/assets/af494c5a-3168-4d16-9c31-b461584a3d5c">


TODO: Add polling for create and restore ops when async tasks are available for them.