### PR TITLE
[CLOUDGA-23292] : Add cluster-name flag to commands to show up in help

### DIFF
--- a/cmd/cluster/connection-pooling/connection_pooling.go
+++ b/cmd/cluster/connection-pooling/connection_pooling.go
@@ -104,6 +104,10 @@ func performConnectionPoolingOperation(operationName string, cmd *cobra.Command,
 
 func init() {
 	util.AddCommandIfFeatureFlag(ConnectionPoolingCmd, enableConnectionPoolingCmd, util.CONNECTION_POOLING)
+	enableConnectionPoolingCmd.Flags().String("cluster-name", "", "[REQUIRED] The name of the cluster to get details.")
+	enableConnectionPoolingCmd.MarkFlagRequired("cluster-name")
 
 	util.AddCommandIfFeatureFlag(ConnectionPoolingCmd, disableConnectionPoolingCmd, util.CONNECTION_POOLING)
+	disableConnectionPoolingCmd.Flags().String("cluster-name", "", "[REQUIRED] The name of the cluster to get details.")
+	disableConnectionPoolingCmd.MarkFlagRequired("cluster-name")
 }


### PR DESCRIPTION
- Closes CLOUDGA-23292
- Tested help command