### PR TITLE
[Feature] Add support for PG Query Log exporter

### DIFF
--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -18,14 +18,15 @@ package cluster
 import (
 	"github.com/spf13/cobra"
 	"github.com/yugabyte/ybm-cli/cmd/cluster/cert"
+	connectionpooling "github.com/yugabyte/ybm-cli/cmd/cluster/connection-pooling"
 	encryption "github.com/yugabyte/ybm-cli/cmd/cluster/encryption"
+	log_exporter "github.com/yugabyte/ybm-cli/cmd/cluster/log-exporter"
 	"github.com/yugabyte/ybm-cli/cmd/cluster/namespace"
 	"github.com/yugabyte/ybm-cli/cmd/cluster/network"
 	"github.com/yugabyte/ybm-cli/cmd/cluster/node"
 	pitrconfig "github.com/yugabyte/ybm-cli/cmd/cluster/pitr-config"
 	readreplica "github.com/yugabyte/ybm-cli/cmd/cluster/read-replica"
 	"github.com/yugabyte/ybm-cli/cmd/util"
-	connectionpooling "github.com/yugabyte/ybm-cli/cmd/cluster/connection-pooling"
 )
 
 // getCmd represents the list command
@@ -40,6 +41,10 @@ var ClusterCmd = &cobra.Command{
 
 func init() {
 	ClusterCmd.AddCommand(cert.CertCmd)
+
+	ClusterCmd.AddCommand(log_exporter.DbQueryLoggingCmd)
+	log_exporter.DbQueryLoggingCmd.PersistentFlags().StringVarP(&log_exporter.ClusterName, "cluster-name", "c", "", "[REQUIRED] The name of the cluster.")
+	log_exporter.DbQueryLoggingCmd.MarkPersistentFlagRequired("cluster-name")
 
 	ClusterCmd.AddCommand(network.NetworkCmd)
 	network.NetworkCmd.PersistentFlags().StringVarP(&network.ClusterName, "cluster-name", "c", "", "[REQUIRED] The name of the cluster.")

--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -43,7 +43,7 @@ var ClusterCmd = &cobra.Command{
 func init() {
 	ClusterCmd.AddCommand(cert.CertCmd)
 
-	ClusterCmd.AddCommand(log_exporter.DbQueryLoggingCmd)
+	util.AddCommandIfFeatureFlag(ClusterCmd, log_exporter.DbQueryLoggingCmd, util.DB_QUERY_LOGS)
 	log_exporter.DbQueryLoggingCmd.PersistentFlags().StringVarP(&log_exporter.ClusterName, "cluster-name", "c", "", "[REQUIRED] The name of the cluster.")
 	log_exporter.DbQueryLoggingCmd.MarkPersistentFlagRequired("cluster-name")
 

--- a/cmd/cluster/log-exporter/query_log_exporter.go
+++ b/cmd/cluster/log-exporter/query_log_exporter.go
@@ -1,0 +1,402 @@
+// Licensed to Yugabyte, Inc. under one or more contributor license
+// agreements. See the NOTICE file distributed with this work for
+// additional information regarding copyright ownership. Yugabyte
+// licenses this file to you under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package query_log_exporter
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	ybmAuthClient "github.com/yugabyte/ybm-cli/internal/client"
+	"github.com/yugabyte/ybm-cli/internal/formatter"
+	ybmclient "github.com/yugabyte/yugabytedb-managed-go-client-internal"
+)
+
+var ClusterName string
+
+var DbQueryLoggingCmd = &cobra.Command{
+	Use:   "db-query-logging",
+	Short: "Configure DB Query Log exporter for your Cluster.",
+	Long:  "Configure DB Query Log exporter for your Cluster.",
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Help()
+	},
+}
+
+var enableDbQueryLoggingCmd = &cobra.Command{
+	Use:   "enable",
+	Short: "Enable DB query log exporter",
+	Long:  "Enable DB query log exporter",
+	Run: func(cmd *cobra.Command, args []string) {
+		authApi, err := ybmAuthClient.NewAuthApiClient()
+		if err != nil {
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
+		}
+		authApi.GetInfo("", "")
+
+		clusterName, _ := cmd.Flags().GetString("cluster-name")
+		if clusterName == "" {
+			logrus.Fatalf("cluster-name must not be empty")
+		}
+
+		exporterId, _ := cmd.Flags().GetString("exporter-id")
+		if exporterId == "" {
+			logrus.Fatalf("exporter-id must not be empty")
+		}
+
+		clusterId, err := authApi.GetClusterIdByName(clusterName)
+		if err != nil {
+			logrus.Fatalf("%s", ybmAuthClient.GetApiErrorDetails(err))
+		}
+
+		exportConfig := BuildNewPgExportConfig(cmd)
+
+		resp, r, err := authApi.EnableDbQueryLogging(clusterId).PgLogExporterConfigSpec(
+			ybmclient.PgLogExporterConfigSpec{ExportConfig: exportConfig, ExporterId: exporterId}).Execute()
+
+		if err != nil {
+			logrus.Debugf("Full HTTP response: %v\n", r)
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
+		}
+
+		DbQueryLoggingContext := formatter.Context{
+			Output: os.Stdout,
+			Format: formatter.NewDbQueryLoggingFormat(),
+		}
+
+		err = formatter.DbQueryLoggingWrite(DbQueryLoggingContext, []ybmclient.PgLogExporterConfigData{resp.GetData()})
+		if err != nil {
+			fmt.Println(err.Error())
+		}
+	},
+}
+
+var describeLogExporterCmd = &cobra.Command{
+	Use:   "describe",
+	Short: "Describe DB query log exporter config",
+	Long:  "Describe DB query log exporter config",
+	Run: func(cmd *cobra.Command, args []string) {
+		authApi, err := ybmAuthClient.NewAuthApiClient()
+		if err != nil {
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
+		}
+		authApi.GetInfo("", "")
+
+		clusterName, _ := cmd.Flags().GetString("cluster-name")
+		clusterId, err := authApi.GetClusterIdByName(clusterName)
+		if err != nil {
+			logrus.Fatalf("%s", ybmAuthClient.GetApiErrorDetails(err))
+		}
+
+		resp, r, err := authApi.GetDbLoggingConfig(clusterId).Execute()
+		if err != nil {
+			logrus.Debugf("Full HTTP response for Query Log Exporter Config: %v\n", r)
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
+		}
+
+		if len(resp.GetData()) < 1 {
+			fmt.Printf("DB query logs are not enabled for cluster: %s\n", clusterName)
+			return
+		}
+
+		DbQueryLoggingContext := formatter.Context{
+			Output: os.Stdout,
+			Format: formatter.NewDbQueryLoggingFormat(),
+		}
+
+		err = formatter.DbQueryLoggingWrite(DbQueryLoggingContext, resp.GetData())
+		if err != nil {
+			fmt.Println(err.Error())
+		}
+	},
+}
+
+var disableLogExporterCmd = &cobra.Command{
+	Use:   "disable",
+	Short: "Disable DB query log exporter",
+	Long:  "Disable DB query log exporter, if enabled",
+	Run: func(cmd *cobra.Command, args []string) {
+		authApi, err := ybmAuthClient.NewAuthApiClient()
+		if err != nil {
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
+		}
+		authApi.GetInfo("", "")
+
+		clusterName, _ := cmd.Flags().GetString("cluster-name")
+		if clusterName == "" {
+			logrus.Fatalf("cluster-name must not be empty")
+		}
+
+		clusterId, err := authApi.GetClusterIdByName(clusterName)
+		if err != nil {
+			logrus.Fatalf("%s", ybmAuthClient.GetApiErrorDetails(err))
+		}
+
+		// Fetch existing log exporter config
+		resp, r, err := authApi.GetDbLoggingConfig(clusterId).Execute()
+		if err != nil {
+			logrus.Debugf("Full HTTP response for Query Log Exporter Config: %v\n", r)
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
+		}
+
+		if len(resp.GetData()) < 1 {
+			fmt.Printf("DB query logs are not enabled for cluster: %s\n", clusterName)
+			return
+		}
+
+		logExporterData := resp.GetData()[0]
+		exporterConfigId := logExporterData.Info.Id
+
+		r, err = authApi.RemoveDbQueryLoggingConfig(clusterId, exporterConfigId).Execute()
+
+		if err != nil {
+			logrus.Debugf("Full HTTP response for disable query logging config: %v\n", r)
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
+		}
+
+		fmt.Printf(`Disabling DB query log config for the cluster, this may take a few minutes...
+You can check the status via $ ybm cluster db-query-logging describe --cluster-name %s%s`, clusterName, "\n")
+	},
+}
+
+var updateLogExporterConfigCmd = &cobra.Command{
+	Use:   "update-config",
+	Short: "Update DB query log exporter config",
+	Long:  "Update DB query log exporter config. Only the config values that are passed in args will be updated, the remaining one's will remain same as existing config.",
+	Run: func(cmd *cobra.Command, args []string) {
+		authApi, err := ybmAuthClient.NewAuthApiClient()
+		if err != nil {
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
+		}
+		authApi.GetInfo("", "")
+
+		clusterName, _ := cmd.Flags().GetString("cluster-name")
+		if clusterName == "" {
+			logrus.Fatalf("cluster-name must not be empty")
+		}
+
+		var exporterId string = ""
+		if cmd.Flags().Changed("exporter-id") { // use exporter id only if provided by user explicitly
+			exporterId, _ = cmd.Flags().GetString("exporter-id")
+		}
+
+		clusterId, err := authApi.GetClusterIdByName(clusterName)
+		if err != nil {
+			logrus.Fatalf("%s", ybmAuthClient.GetApiErrorDetails(err))
+		}
+
+		// Fetch existing log exporter config
+		resp, r, err := authApi.GetDbLoggingConfig(clusterId).Execute()
+		if err != nil {
+			logrus.Debugf("Full HTTP response for Query Log Exporter Config: %v\n", r)
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
+		}
+
+		if len(resp.GetData()) < 1 {
+			fmt.Printf("DB query logs are not enabled for cluster: %s\n", clusterName)
+			return
+		}
+
+		logExporterData := resp.GetData()[0]
+		exporterConfigId := logExporterData.Info.Id
+
+		// Use existing exporterId if it is not provided by user
+		if exporterId == "" {
+			exporterId = logExporterData.Spec.ExporterId
+		}
+
+		existingExportConfig := logExporterData.Spec.ExportConfig
+		newExportConfig := BuildNewPgExportConfigFromExistingConfig(cmd, existingExportConfig)
+
+		var pgLogExporterConfigResponse ybmclient.PgLogExporterConfigResponse
+		pgLogExporterConfigResponse, r, err = authApi.EditDbQueryLoggingConfig(clusterId, exporterConfigId).PgLogExporterConfigSpec(
+			ybmclient.PgLogExporterConfigSpec{ExportConfig: newExportConfig, ExporterId: exporterId}).Execute()
+
+		if err != nil {
+			logrus.Debugf("Full HTTP response for update DB Query logging config: %v\n", r)
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
+		}
+
+		DbQueryLoggingContext := formatter.Context{
+			Output: os.Stdout,
+			Format: formatter.NewDbQueryLoggingFormat(),
+		}
+
+		err = formatter.DbQueryLoggingWrite(DbQueryLoggingContext,
+			[]ybmclient.PgLogExporterConfigData{pgLogExporterConfigResponse.GetData()})
+		if err != nil {
+			fmt.Println(err.Error())
+		}
+	},
+}
+
+func init() {
+
+	DbQueryLoggingCmd.AddCommand(enableDbQueryLoggingCmd)
+	enableDbQueryLoggingCmd.Flags().SortFlags = false
+	enableDbQueryLoggingCmd.Flags().String("exporter-id", "", "[REQUIRED] Exporter ID to which logs should be exported(can be fetched by $ ybm integration list).")
+	enableDbQueryLoggingCmd.MarkFlagRequired("exporter-id")
+	enableDbQueryLoggingCmd.Flags().String("debug-print-plan", "false", "[OPTIONAL] Enables various debugging output to be emitted.")
+	enableDbQueryLoggingCmd.Flags().Int32("log-min-duration-statement", -1, "[OPTIONAL] Duration(in ms) of each completed statement to be logged if the statement ran for at least the specified amount of time. Default -1 (log all statements).")
+	enableDbQueryLoggingCmd.Flags().String("log-connections", "false", "[OPTIONAL] Log connection attempts.")
+	enableDbQueryLoggingCmd.Flags().String("log-disconnections", "false", "[OPTIONAL] Log session disconnections.")
+	enableDbQueryLoggingCmd.Flags().String("log-duration", "false", "[OPTIONAL] Log the duration of each completed statement.")
+	enableDbQueryLoggingCmd.Flags().String("log-error-verbosity", "DEFAULT", "[OPTIONAL] Controls the amount of detail written in the server log for each message that is logged. Options: DEFAULT, TERSE, VERBOSE.")
+	enableDbQueryLoggingCmd.Flags().String("log-statement", "NONE", "[OPTIONAL] Log all statements or specific types of statements. Options: NONE, DDL, MOD, ALL.")
+	enableDbQueryLoggingCmd.Flags().String("log-min-error-statement", "ERROR", "[OPTIONAL] Minimum error severity for logging the statement that caused it. Options: ERROR.")
+	enableDbQueryLoggingCmd.Flags().String("log-line-prefix", "%m :%r :%u @ %d :[%p] :", "[OPTIONAL] A printf-style format string for log line prefixes.")
+
+	DbQueryLoggingCmd.AddCommand(updateLogExporterConfigCmd)
+	updateLogExporterConfigCmd.Flags().String("exporter-id", "", "[OPTIONAL] Exporter ID to which logs should be exported(can be fetched by $ ybm integration list).")
+	updateLogExporterConfigCmd.Flags().String("debug-print-plan", "", "[OPTIONAL] Enables various debugging output to be emitted.")
+	updateLogExporterConfigCmd.Flags().Int32("log-min-duration-statement", -1, "[OPTIONAL] Duration(in ms) of each completed statement to be logged if the statement ran for at least the specified amount of time.")
+	updateLogExporterConfigCmd.Flags().String("log-connections", "", "[OPTIONAL] Log connection attempts.")
+	updateLogExporterConfigCmd.Flags().String("log-disconnections", "", "[OPTIONAL] Log session disconnections.")
+	updateLogExporterConfigCmd.Flags().String("log-duration", "", "[OPTIONAL] Log the duration of each completed statement.")
+	updateLogExporterConfigCmd.Flags().String("log-error-verbosity", "", "[OPTIONAL] Controls the amount of detail written in the server log for each message that is logged. Options: DEFAULT, TERSE, VERBOSE.")
+	updateLogExporterConfigCmd.Flags().String("log-statement", "", "[OPTIONAL] Log all statements or specific types of statements. Options: NONE, DDL, MOD, ALL.")
+	updateLogExporterConfigCmd.Flags().String("log-min-error-statement", "", "[OPTIONAL] Minimum error severity for logging the statement that caused it. Options: ERROR.")
+	updateLogExporterConfigCmd.Flags().String("log-line-prefix", "", "[OPTIONAL] A printf-style format string for log line prefixes.")
+
+	DbQueryLoggingCmd.AddCommand(describeLogExporterCmd)
+	DbQueryLoggingCmd.AddCommand(disableLogExporterCmd)
+}
+
+func BuildNewPgExportConfig(cmd *cobra.Command) ybmclient.PgLogExportConfig {
+	// Build a new PgLogExportConfig from args
+	config := ybmclient.PgLogExportConfig{}
+
+	logMinDurationStatement, _ := cmd.Flags().GetInt32("log-min-duration-statement")
+	config.LogMinDurationStatement = logMinDurationStatement
+
+	debugPrintPlan, _ := cmd.Flags().GetString("debug-print-plan")
+	config.DebugPrintPlan = ParseBoolString(debugPrintPlan)
+
+	logConnections, _ := cmd.Flags().GetString("log-connections")
+	config.LogConnections = ParseBoolString(logConnections)
+
+	logDisconnections, _ := cmd.Flags().GetString("log-disconnections")
+	config.LogDisconnections = ParseBoolString(logDisconnections)
+
+	logDuration, _ := cmd.Flags().GetString("log-duration")
+	config.LogDuration = ParseBoolString(logDuration)
+
+	if logErrorVerbosity, _ := cmd.Flags().GetString("log-error-verbosity"); logErrorVerbosity != "" {
+		logErrorVerbosityEnum, err := ybmclient.NewLogErrorVerbosityEnumFromValue(strings.ToUpper(logErrorVerbosity))
+		if err != nil {
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
+		}
+		config.LogErrorVerbosity = *logErrorVerbosityEnum
+	}
+
+	if logStatement, _ := cmd.Flags().GetString("log-statement"); logStatement != "" {
+		logStatementEnum, err := ybmclient.NewLogStatementEnumFromValue(strings.ToUpper(logStatement))
+		if err != nil {
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
+		}
+		config.LogStatement = *logStatementEnum
+	}
+
+	if logMinErrorStatement, _ := cmd.Flags().GetString("log-min-error-statement"); logMinErrorStatement != "" {
+		logMinErrorStatementEnum, err := ybmclient.NewLogMinErrorStatementEnumFromValue(strings.ToUpper(logMinErrorStatement))
+		if err != nil {
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
+		}
+		config.LogMinErrorStatement = *logMinErrorStatementEnum
+	}
+
+	if logLinePrefix, _ := cmd.Flags().GetString("log-line-prefix"); logLinePrefix != "" {
+		config.LogLinePrefix = logLinePrefix
+	}
+
+	return config
+}
+
+func BuildNewPgExportConfigFromExistingConfig(cmd *cobra.Command, existingConfig ybmclient.PgLogExportConfig) ybmclient.PgLogExportConfig {
+	// Copy existing config and only update the fields that are explicitly provided in args
+	// This is to ensure that we do not set the flags(which are not provided in args) back to default values.
+	var newConfig = existingConfig
+
+	if cmd.Flags().Changed("log-min-duration-statement") {
+		logMinDurationStatement, _ := cmd.Flags().GetInt32("log-min-duration-statement")
+		newConfig.LogMinDurationStatement = logMinDurationStatement
+	}
+
+	if cmd.Flags().Changed("debug-print-plan") {
+		debugPrintPlan, _ := cmd.Flags().GetString("debug-print-plan")
+		newConfig.DebugPrintPlan = ParseBoolString(debugPrintPlan)
+	}
+
+	if cmd.Flags().Changed("log-connections") {
+		logConnections, _ := cmd.Flags().GetString("log-connections")
+		newConfig.LogConnections = ParseBoolString(logConnections)
+	}
+
+	if cmd.Flags().Changed("log-disconnections") {
+		logDisconnections, _ := cmd.Flags().GetString("log-disconnections")
+		newConfig.LogDisconnections = ParseBoolString(logDisconnections)
+	}
+
+	if cmd.Flags().Changed("log-duration") {
+		logDuration, _ := cmd.Flags().GetString("log-duration")
+		newConfig.LogDuration = ParseBoolString(logDuration)
+	}
+
+	if cmd.Flags().Changed("log-line-prefix") {
+		logLinePrefix, _ := cmd.Flags().GetString("log-line-prefix")
+		newConfig.LogLinePrefix = logLinePrefix
+	}
+
+	if cmd.Flags().Changed("log-error-verbosity") {
+		logErrorVerbosity, _ := cmd.Flags().GetString("log-error-verbosity")
+		logErrorVerbosityEnum, err := ybmclient.NewLogErrorVerbosityEnumFromValue(strings.ToUpper(logErrorVerbosity))
+		if err != nil {
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
+		}
+		newConfig.LogErrorVerbosity = *logErrorVerbosityEnum
+	}
+
+	if cmd.Flags().Changed("log-statement") {
+		logStatement, _ := cmd.Flags().GetString("log-statement")
+		logStatementEnum, err := ybmclient.NewLogStatementEnumFromValue(strings.ToUpper(logStatement))
+		if err != nil {
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
+		}
+		newConfig.LogStatement = *logStatementEnum
+	}
+
+	if cmd.Flags().Changed("log-min-error-statement") {
+		logMinErrorStatement, _ := cmd.Flags().GetString("log-min-error-statement")
+		logMinErrorStatementEnum, err := ybmclient.NewLogMinErrorStatementEnumFromValue(strings.ToUpper(logMinErrorStatement))
+		if err != nil {
+			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
+		}
+		newConfig.LogMinErrorStatement = *logMinErrorStatementEnum
+	}
+
+	return newConfig
+}
+
+func ParseBoolString(input string) bool {
+	result, err := strconv.ParseBool(input)
+	if err != nil {
+		logrus.Fatalf("invalid boolean value \"%s\": expected true/false or 1/0", input)
+	}
+	return result
+}

--- a/cmd/cluster/log-exporter/query_log_exporter.go
+++ b/cmd/cluster/log-exporter/query_log_exporter.go
@@ -34,8 +34,8 @@ var ClusterName string
 
 var DbQueryLoggingCmd = &cobra.Command{
 	Use:   "db-query-logging",
-	Short: "Configure DB Query Log exporter for your Cluster.",
-	Long:  "Configure DB Query Log exporter for your Cluster.",
+	Short: "Configure Database Query Logging for your Cluster.",
+	Long:  "Configure Database Query Logging for your Cluster.",
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()
 	},
@@ -43,8 +43,8 @@ var DbQueryLoggingCmd = &cobra.Command{
 
 var enableDbQueryLoggingCmd = &cobra.Command{
 	Use:   "enable",
-	Short: "Enable DB query log exporter",
-	Long:  "Enable DB query log exporter",
+	Short: "Enable Database Query Logging",
+	Long:  "Enable Database Query Logging",
 	Run: func(cmd *cobra.Command, args []string) {
 		authApi, err := ybmAuthClient.NewAuthApiClient()
 		if err != nil {
@@ -89,8 +89,8 @@ var enableDbQueryLoggingCmd = &cobra.Command{
 
 var describeLogExporterCmd = &cobra.Command{
 	Use:   "describe",
-	Short: "Describe DB query log exporter config",
-	Long:  "Describe DB query log exporter config",
+	Short: "Describe Database Query Logging config",
+	Long:  "Describe Database Query Logging config",
 	Run: func(cmd *cobra.Command, args []string) {
 		authApi, err := ybmAuthClient.NewAuthApiClient()
 		if err != nil {
@@ -129,8 +129,8 @@ var describeLogExporterCmd = &cobra.Command{
 
 var disableLogExporterCmd = &cobra.Command{
 	Use:   "disable",
-	Short: "Disable DB query log exporter",
-	Long:  "Disable DB query log exporter, if enabled",
+	Short: "Disable Database Query Logging",
+	Long:  "Disable Database Query Logging, if enabled",
 	PreRun: func(cmd *cobra.Command, args []string) {
 		viper.BindPFlag("force", cmd.Flags().Lookup("force"))
 		clusterName, _ := cmd.Flags().GetString("cluster-name")
@@ -185,8 +185,8 @@ You can check the status via $ ybm cluster db-query-logging describe --cluster-n
 
 var updateLogExporterConfigCmd = &cobra.Command{
 	Use:   "update",
-	Short: "Update DB query log exporter config",
-	Long:  "Update DB query log exporter config. Only the config values that are passed in args will be updated, the remaining one's will remain same as existing config.",
+	Short: "Update Database Query Logging config",
+	Long:  "Update Database Query Logging config. Only the config values that are passed in args will be updated, the remaining one's will remain same as existing config.",
 	Run: func(cmd *cobra.Command, args []string) {
 		authApi, err := ybmAuthClient.NewAuthApiClient()
 		if err != nil {

--- a/cmd/cluster/log-exporter/query_log_exporter.go
+++ b/cmd/cluster/log-exporter/query_log_exporter.go
@@ -31,7 +31,7 @@ import (
 var ClusterName string
 
 var DbQueryLoggingCmd = &cobra.Command{
-	Use:   "db-query-logging",
+	Use:   "db-query-log-exporter",
 	Short: "Configure DB Query Log exporter for your Cluster.",
 	Long:  "Configure DB Query Log exporter for your Cluster.",
 	Run: func(cmd *cobra.Command, args []string) {
@@ -171,7 +171,7 @@ var disableLogExporterCmd = &cobra.Command{
 		}
 
 		fmt.Printf(`Disabling DB query log config for the cluster, this may take a few minutes...
-You can check the status via $ ybm cluster db-query-logging describe --cluster-name %s%s`, clusterName, "\n")
+You can check the status via $ ybm cluster db-query-log-exporter describe --cluster-name %s%s`, clusterName, "\n")
 	},
 }
 

--- a/cmd/db_query_logs_exporter_test.go
+++ b/cmd/db_query_logs_exporter_test.go
@@ -1,0 +1,250 @@
+// Licensed to Yugabyte, Inc. under one or more contributor license
+// agreements. See the NOTICE file distributed with this work for
+// additional information regarding copyright ownership. Yugabyte
+// licenses this file to you under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmd_test
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gexec"
+	"github.com/onsi/gomega/ghttp"
+	openapi "github.com/yugabyte/yugabytedb-managed-go-client-internal"
+)
+
+var _ = Describe("DB Query Logging", func() {
+
+	var (
+		server                          *ghttp.Server
+		statusCode                      int
+		args                            []string
+		responseAccount                 openapi.AccountListResponse
+		responseProject                 openapi.AccountListResponse
+		pgLogExporterResponse           openapi.PgLogExporterConfigResponse
+		pgLogExporterConfigListResponse openapi.PgLogExporterConfigListResponse
+		responseListClusters            openapi.ClusterListResponse
+	)
+
+	BeforeEach(func() {
+		args = os.Args
+		os.Args = []string{}
+		var err error
+		server, err = newGhttpServer(responseAccount, responseProject)
+		Expect(err).ToNot(HaveOccurred())
+		os.Setenv("YBM_HOST", fmt.Sprintf("http://%s", server.Addr()))
+		os.Setenv("YBM_APIKEY", "test-token")
+		statusCode = 200
+		err = loadJson("./test/fixtures/list-clusters.json", &responseListClusters)
+		Expect(err).ToNot(HaveOccurred())
+		server.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/clusters"),
+				ghttp.RespondWithJSONEncodedPtr(&statusCode, responseListClusters),
+			),
+		)
+	})
+
+	Describe("When enabling query log exporter", func() {
+		Context("with exporter-id not set", func() {
+			It("should throw error, exporter-id not set", func() {
+				cmd := exec.Command(compiledCLIPath, "cluster", "db-query-logging", "enable", "--cluster-name", "stunning-sole")
+				session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+
+				Expect(err).NotTo(HaveOccurred())
+				session.Wait(2)
+				Expect(session.Err).Should(gbytes.Say(`\bError: required flag\(s\) "exporter-id" not set\b`))
+				session.Kill()
+			})
+		})
+		Context("without log config params", func() {
+			It("should enable db query logs with default log configs", func() {
+				err := loadJson("./test/fixtures/db-query-log-exporter.json", &pgLogExporterResponse)
+				Expect(err).ToNot(HaveOccurred())
+
+				statusCode = 202
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest(http.MethodPost, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/cluster/5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8/db-query-log-exporter-configs"),
+						ghttp.RespondWithJSONEncodedPtr(&statusCode, pgLogExporterResponse),
+					),
+				)
+
+				cmd := exec.Command(compiledCLIPath, "cluster", "db-query-logging", "enable",
+					"--cluster-name", "stunning-sole",
+					"--exporter-id", "9e740000-331b-4dec-89b0-4e59b81e9019",
+				)
+				session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+
+				Expect(err).NotTo(HaveOccurred())
+				session.Wait(2)
+				// Specials characters like $ % [ ] etc must be escaped using backslash to do exact matching
+				Expect(session.Out).Should(gbytes.Say(`State      Exporter ID                            Log Config
+ENABLING   9e740000-331b-4dec-89b0-4e59b81e9019   {"debug_print_plan":false,"log_connections":false,"log_disconnections":false,"log_duration":false,"log_error_verbosity":"DEFAULT","log_line_prefix":"\%m :\%r :\%u @ \%d :\[\%p\] :","log_min_duration_statement":-1,"log_min_error_statement":"ERROR","log_statement":"NONE"}`))
+				Expect(server.ReceivedRequests()).Should(HaveLen(4))
+				session.Kill()
+			})
+		})
+		Context("with log config params", func() {
+			It("should enable db query logs with provided log configs", func() {
+				err := loadJson("./test/fixtures/db-query-log-exporter-custom.json", &pgLogExporterResponse)
+				Expect(err).ToNot(HaveOccurred())
+
+				statusCode = 202
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest(http.MethodPost, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/cluster/5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8/db-query-log-exporter-configs"),
+						ghttp.RespondWithJSONEncodedPtr(&statusCode, pgLogExporterResponse),
+					),
+				)
+
+				cmd := exec.Command(compiledCLIPath, "cluster", "db-query-logging", "enable",
+					"--cluster-name", "stunning-sole",
+					"--exporter-id", "9e740000-331b-4dec-89b0-4e59b81e9019",
+					"--debug-print-plan", "true",
+					"--log-connections", "true",
+					"--log-disconnections", "false",
+					"--log-duration", "false",
+					"--log-error-verbosity", "TERSE",
+					"--log-line-prefix", "%m :%r :%u @ %d :[%p] : %a :",
+					"--log-min-duration-statement", "50",
+					"--log-min-error-statement", "ERROR",
+					"--log-statement", "MOD",
+				)
+				session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+
+				Expect(err).NotTo(HaveOccurred())
+				session.Wait(2)
+				Expect(session.Out).Should(gbytes.Say(`State      Exporter ID                            Log Config
+ENABLING   9e740000-331b-4dec-89b0-4e59b81e9019   {"debug_print_plan":true,"log_connections":true,"log_disconnections":false,"log_duration":false,"log_error_verbosity":"TERSE","log_line_prefix":"\%m :\%r :\%u @ \%d :\[\%p\] : \%a :","log_min_duration_statement":50,"log_min_error_statement":"ERROR","log_statement":"MOD"}`))
+				Expect(server.ReceivedRequests()).Should(HaveLen(4))
+				session.Kill()
+			})
+		})
+	})
+
+	Describe("When disabling query log exporter", func() {
+		Context("with logs enabled", func() {
+			It("should disable query logs exporter", func() {
+				err := loadJson("./test/fixtures/db-query-log-exporter-describe-resp.json", &pgLogExporterConfigListResponse)
+				Expect(err).ToNot(HaveOccurred())
+				statusCode = 200
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest(http.MethodGet, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/cluster/5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8/db-query-log-exporter-configs"),
+						ghttp.RespondWithJSONEncodedPtr(&statusCode, pgLogExporterConfigListResponse),
+					),
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest(http.MethodDelete, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/cluster/5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8/db-query-log-exporter-configs/388c41b9-81f7-4ed9-8239-ab22f4aaca91"),
+						ghttp.RespondWith(202, nil),
+					),
+				)
+
+				cmd := exec.Command(compiledCLIPath, "cluster", "db-query-logging", "disable",
+					"--cluster-name", "stunning-sole",
+				)
+				session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+
+				Expect(err).NotTo(HaveOccurred())
+				session.Wait(2)
+				Expect(session.Out).Should(gbytes.Say(`Disabling DB query log config for the cluster, this may take a few minutes...
+You can check the status via \$ ybm cluster db-query-logging describe --cluster-name stunning-sole`))
+				Expect(server.ReceivedRequests()).Should(HaveLen(5))
+				session.Kill()
+			})
+		})
+	})
+	Describe("When describe query log exporter", func() {
+		It("should show a summary for query logs exporter", func() {
+			err := loadJson("./test/fixtures/db-query-log-exporter-describe-resp.json", &pgLogExporterConfigListResponse)
+			Expect(err).ToNot(HaveOccurred())
+			statusCode = 200
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/cluster/5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8/db-query-log-exporter-configs"),
+					ghttp.RespondWithJSONEncodedPtr(&statusCode, pgLogExporterConfigListResponse),
+				),
+			)
+
+			cmd := exec.Command(compiledCLIPath, "cluster", "db-query-logging", "describe",
+				"--cluster-name", "stunning-sole",
+			)
+			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+
+			Expect(err).NotTo(HaveOccurred())
+			session.Wait(2)
+			Expect(session.Out).Should(gbytes.Say(`State     Exporter ID                            Log Config
+ACTIVE    9e740000-331b-4dec-89b0-4e59b81e9019   {"debug_print_plan":false,"log_connections":true,"log_disconnections":false,"log_duration":false,"log_error_verbosity":"DEFAULT","log_line_prefix":"\%m :\%r :\%u @ \%d :\[\%p\] : \%a :","log_min_duration_statement":30,"log_min_error_statement":"ERROR","log_statement":"MOD"}`))
+			Expect(server.ReceivedRequests()).Should(HaveLen(4))
+			session.Kill()
+		})
+	})
+
+	Describe("When updating query log exporter config", func() {
+		It("should update log config with provided args", func() {
+			// Load existing log export config
+			err := loadJson("./test/fixtures/db-query-log-exporter-describe-resp.json", &pgLogExporterConfigListResponse)
+			Expect(err).ToNot(HaveOccurred())
+
+			statusCode = 200
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/cluster/5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8/db-query-log-exporter-configs"),
+					ghttp.RespondWithJSONEncodedPtr(&statusCode, pgLogExporterConfigListResponse),
+				),
+			)
+
+			// Load updated log export config response
+			err = loadJson("./test/fixtures/db-query-log-exporter-update-config-resp.json", &pgLogExporterResponse)
+			Expect(err).ToNot(HaveOccurred())
+
+			statusCode = 202
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodPut, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/cluster/5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8/db-query-log-exporter-configs/388c41b9-81f7-4ed9-8239-ab22f4aaca91"),
+					ghttp.RespondWithJSONEncodedPtr(&statusCode, pgLogExporterResponse),
+				),
+			)
+
+			cmd := exec.Command(compiledCLIPath, "cluster", "db-query-logging", "update-config",
+				"--cluster-name", "stunning-sole",
+				"--exporter-id", "9e740000-331b-4dec-89b0-4e59b81e9019",
+				// Change few query log configs
+				"--debug-print-plan", "true",
+				"--log-connections", "false",
+				"--log-min-duration-statement", "60",
+				"--log-statement", "ALL",
+			)
+			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+
+			Expect(err).NotTo(HaveOccurred())
+			session.Wait(2)
+			Expect(session.Out).Should(gbytes.Say(`State     Exporter ID                            Log Config
+ACTIVE    9e740000-331b-4dec-89b0-4e59b81e9019   {"debug_print_plan":true,"log_connections":false,"log_disconnections":false,"log_duration":false,"log_error_verbosity":"DEFAULT","log_line_prefix":"\%m :\%r :\%u @ \%d :\[\%p\] : \%a :","log_min_duration_statement":60,"log_min_error_statement":"ERROR","log_statement":"ALL"}`))
+			Expect(server.ReceivedRequests()).Should(HaveLen(5))
+			session.Kill()
+		})
+	})
+
+	AfterEach(func() {
+		os.Args = args
+		server.Close()
+	})
+
+})

--- a/cmd/db_query_logs_exporter_test.go
+++ b/cmd/db_query_logs_exporter_test.go
@@ -64,7 +64,7 @@ var _ = Describe("DB Query Logging", func() {
 	Describe("When enabling query log exporter", func() {
 		Context("with exporter-id not set", func() {
 			It("should throw error, exporter-id not set", func() {
-				cmd := exec.Command(compiledCLIPath, "cluster", "db-query-logging", "enable", "--cluster-name", "stunning-sole")
+				cmd := exec.Command(compiledCLIPath, "cluster", "db-query-log-exporter", "enable", "--cluster-name", "stunning-sole")
 				session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 
 				Expect(err).NotTo(HaveOccurred())
@@ -86,7 +86,7 @@ var _ = Describe("DB Query Logging", func() {
 					),
 				)
 
-				cmd := exec.Command(compiledCLIPath, "cluster", "db-query-logging", "enable",
+				cmd := exec.Command(compiledCLIPath, "cluster", "db-query-log-exporter", "enable",
 					"--cluster-name", "stunning-sole",
 					"--exporter-id", "9e740000-331b-4dec-89b0-4e59b81e9019",
 				)
@@ -114,7 +114,7 @@ ENABLING   9e740000-331b-4dec-89b0-4e59b81e9019   {"debug_print_plan":false,"log
 					),
 				)
 
-				cmd := exec.Command(compiledCLIPath, "cluster", "db-query-logging", "enable",
+				cmd := exec.Command(compiledCLIPath, "cluster", "db-query-log-exporter", "enable",
 					"--cluster-name", "stunning-sole",
 					"--exporter-id", "9e740000-331b-4dec-89b0-4e59b81e9019",
 					"--debug-print-plan", "true",
@@ -156,7 +156,7 @@ ENABLING   9e740000-331b-4dec-89b0-4e59b81e9019   {"debug_print_plan":true,"log_
 					),
 				)
 
-				cmd := exec.Command(compiledCLIPath, "cluster", "db-query-logging", "disable",
+				cmd := exec.Command(compiledCLIPath, "cluster", "db-query-log-exporter", "disable",
 					"--cluster-name", "stunning-sole",
 				)
 				session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
@@ -164,7 +164,7 @@ ENABLING   9e740000-331b-4dec-89b0-4e59b81e9019   {"debug_print_plan":true,"log_
 				Expect(err).NotTo(HaveOccurred())
 				session.Wait(2)
 				Expect(session.Out).Should(gbytes.Say(`Disabling DB query log config for the cluster, this may take a few minutes...
-You can check the status via \$ ybm cluster db-query-logging describe --cluster-name stunning-sole`))
+You can check the status via \$ ybm cluster db-query-log-exporter describe --cluster-name stunning-sole`))
 				Expect(server.ReceivedRequests()).Should(HaveLen(5))
 				session.Kill()
 			})
@@ -182,7 +182,7 @@ You can check the status via \$ ybm cluster db-query-logging describe --cluster-
 				),
 			)
 
-			cmd := exec.Command(compiledCLIPath, "cluster", "db-query-logging", "describe",
+			cmd := exec.Command(compiledCLIPath, "cluster", "db-query-log-exporter", "describe",
 				"--cluster-name", "stunning-sole",
 			)
 			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
@@ -222,7 +222,7 @@ ACTIVE    9e740000-331b-4dec-89b0-4e59b81e9019   {"debug_print_plan":false,"log_
 				),
 			)
 
-			cmd := exec.Command(compiledCLIPath, "cluster", "db-query-logging", "update-config",
+			cmd := exec.Command(compiledCLIPath, "cluster", "db-query-log-exporter", "update-config",
 				"--cluster-name", "stunning-sole",
 				"--exporter-id", "9e740000-331b-4dec-89b0-4e59b81e9019",
 				// Change few query log configs

--- a/cmd/db_query_logs_exporter_test.go
+++ b/cmd/db_query_logs_exporter_test.go
@@ -51,6 +51,7 @@ var _ = Describe("DB Query Logging", func() {
 		Expect(err).ToNot(HaveOccurred())
 		os.Setenv("YBM_HOST", fmt.Sprintf("http://%s", server.Addr()))
 		os.Setenv("YBM_APIKEY", "test-token")
+		os.Setenv("YBM_FF_DB_QUERY_LOGS", "true")
 		statusCode = 200
 		err = loadJson("./test/fixtures/list-clusters.json", &responseListClusters)
 		Expect(err).ToNot(HaveOccurred())

--- a/cmd/db_query_logs_exporter_test.go
+++ b/cmd/db_query_logs_exporter_test.go
@@ -65,7 +65,7 @@ var _ = Describe("DB Query Logging", func() {
 	Describe("When enabling query log exporter", func() {
 		Context("with integration-name not set", func() {
 			It("should throw error, integration-name not set", func() {
-				cmd := exec.Command(compiledCLIPath, "cluster", "db-query-log-exporter", "enable", "--cluster-name", "stunning-sole")
+				cmd := exec.Command(compiledCLIPath, "cluster", "db-query-logging", "enable", "--cluster-name", "stunning-sole")
 				session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 
 				Expect(err).NotTo(HaveOccurred())
@@ -98,7 +98,7 @@ var _ = Describe("DB Query Logging", func() {
 					),
 				)
 
-				cmd := exec.Command(compiledCLIPath, "cluster", "db-query-log-exporter", "enable",
+				cmd := exec.Command(compiledCLIPath, "cluster", "db-query-logging", "enable",
 					"--cluster-name", "stunning-sole",
 					"--integration-name", "datadog-tp",
 				)
@@ -137,7 +137,7 @@ ENABLING   9e740000-331b-4dec-89b0-4e59b81e9019   {"debug_print_plan":false,"log
 					),
 				)
 
-				cmd := exec.Command(compiledCLIPath, "cluster", "db-query-log-exporter", "enable",
+				cmd := exec.Command(compiledCLIPath, "cluster", "db-query-logging", "enable",
 					"--cluster-name", "stunning-sole",
 					"--integration-name", "datadog-tp",
 					"--debug-print-plan", "true",
@@ -179,8 +179,8 @@ ENABLING   9e740000-331b-4dec-89b0-4e59b81e9019   {"debug_print_plan":true,"log_
 					),
 				)
 
-				cmd := exec.Command(compiledCLIPath, "cluster", "db-query-log-exporter", "disable",
-					"--cluster-name", "stunning-sole",
+				cmd := exec.Command(compiledCLIPath, "cluster", "db-query-logging", "disable",
+					"--cluster-name", "stunning-sole", "-f",
 				)
 				session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 
@@ -205,7 +205,7 @@ You can check the status via \$ ybm cluster db-query-logging describe --cluster-
 				),
 			)
 
-			cmd := exec.Command(compiledCLIPath, "cluster", "db-query-log-exporter", "describe",
+			cmd := exec.Command(compiledCLIPath, "cluster", "db-query-logging", "describe",
 				"--cluster-name", "stunning-sole",
 			)
 			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
@@ -245,7 +245,7 @@ ACTIVE    9e740000-331b-4dec-89b0-4e59b81e9019   {"debug_print_plan":false,"log_
 				),
 			)
 
-			cmd := exec.Command(compiledCLIPath, "cluster", "db-query-log-exporter", "update",
+			cmd := exec.Command(compiledCLIPath, "cluster", "db-query-logging", "update",
 				"--cluster-name", "stunning-sole",
 				// Change few query log configs
 				"--debug-print-plan", "true",

--- a/cmd/test/fixtures/db-query-log-exporter-custom.json
+++ b/cmd/test/fixtures/db-query-log-exporter-custom.json
@@ -1,0 +1,27 @@
+{
+    "data": {
+      "spec": {
+        "export_config": {
+          "log_min_duration_statement": 50,
+          "debug_print_plan": true,
+          "log_connections": true,
+          "log_disconnections": false,
+          "log_duration": false,
+          "log_error_verbosity": "TERSE",
+          "log_statement": "MOD",
+          "log_min_error_statement": "ERROR",
+          "log_line_prefix": "%m :%r :%u @ %d :[%p] : %a :"
+        },
+        "exporter_id": "9e740000-331b-4dec-89b0-4e59b81e9019"
+      },
+      "info": {
+        "id": "6ddb35d2-c41d-4ee0-9fa9-6d50cbb2a6f9",
+        "cluster_id": "5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8",
+        "state": "ENABLING",
+        "metadata": {
+          "created_on": "2021-01-30",
+          "updated_on": "2021-01-30"
+        }
+      }
+    }
+  }

--- a/cmd/test/fixtures/db-query-log-exporter-describe-resp.json
+++ b/cmd/test/fixtures/db-query-log-exporter-describe-resp.json
@@ -1,0 +1,29 @@
+{
+    "data": [
+        {
+            "spec": {
+                "export_config": {
+                    "debug_print_plan": false,
+                    "log_connections": true,
+                    "log_disconnections": false,
+                    "log_duration": false,
+                    "log_error_verbosity": "DEFAULT",
+                    "log_line_prefix": "%m :%r :%u @ %d :[%p] : %a :",
+                    "log_min_duration_statement": 30,
+                    "log_min_error_statement": "ERROR",
+                    "log_statement": "MOD"
+                },
+                "exporter_id": "9e740000-331b-4dec-89b0-4e59b81e9019"
+            },
+            "info": {
+                "id": "388c41b9-81f7-4ed9-8239-ab22f4aaca91",
+                "cluster_id": "5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8",
+                "state": "ACTIVE",
+                "metadata": {
+                    "created_on": "2024-10-07T10:28:55.148Z",
+                    "updated_on": "2024-10-15T04:33:41.263Z"
+                }
+            }
+        }
+    ]
+}

--- a/cmd/test/fixtures/db-query-log-exporter-update-config-resp.json
+++ b/cmd/test/fixtures/db-query-log-exporter-update-config-resp.json
@@ -1,0 +1,28 @@
+{
+    "data": 
+        {
+            "spec": {
+                "export_config": {
+                    "debug_print_plan": true,
+                    "log_connections": false,
+                    "log_disconnections": false,
+                    "log_duration": false,
+                    "log_error_verbosity": "DEFAULT",
+                    "log_line_prefix": "%m :%r :%u @ %d :[%p] : %a :",
+                    "log_min_duration_statement": 60,
+                    "log_min_error_statement": "ERROR",
+                    "log_statement": "ALL"
+                },
+                "exporter_id": "9e740000-331b-4dec-89b0-4e59b81e9019"
+            },
+            "info": {
+                "id": "388c41b9-81f7-4ed9-8239-ab22f4aaca91",
+                "cluster_id": "5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8",
+                "state": "ACTIVE",
+                "metadata": {
+                    "created_on": "2024-10-07T10:28:55.148Z",
+                    "updated_on": "2024-10-15T04:33:41.263Z"
+                }
+            }
+        }
+}

--- a/cmd/test/fixtures/db-query-log-exporter.json
+++ b/cmd/test/fixtures/db-query-log-exporter.json
@@ -1,0 +1,27 @@
+{
+    "data": {
+      "spec": {
+        "export_config": {
+          "log_min_duration_statement": -1,
+          "debug_print_plan": false,
+          "log_connections": false,
+          "log_disconnections": false,
+          "log_duration": false,
+          "log_error_verbosity": "DEFAULT",
+          "log_statement": "NONE",
+          "log_min_error_statement": "ERROR",
+          "log_line_prefix": "%m :%r :%u @ %d :[%p] :"
+        },
+        "exporter_id": "9e740000-331b-4dec-89b0-4e59b81e9019"
+      },
+      "info": {
+        "id": "6ddb35d2-c41d-4ee0-9fa9-6d50cbb2a6f9",
+        "cluster_id": "5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8",
+        "state": "ENABLING",
+        "metadata": {
+          "created_on": "2021-01-30",
+          "updated_on": "2021-01-30"
+        }
+      }
+    }
+  }

--- a/cmd/util/feature_flags.go
+++ b/cmd/util/feature_flags.go
@@ -36,6 +36,7 @@ const (
 	CONNECTION_POOLING      FeatureFlag = "CONNECTION_POOLING"
 	GOOGLECLOUD_INTEGRATION FeatureFlag = "GOOGLECLOUD_INTEGRATION"
 	DR                      FeatureFlag = "DR"
+	DB_QUERY_LOGS           FeatureFlag = "DB_QUERY_LOGS"
 )
 
 func (f FeatureFlag) String() string {

--- a/go.sum
+++ b/go.sum
@@ -282,8 +282,6 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/t-tomalak/logrus-easy-formatter v0.0.0-20190827215021-c074f06c5816 h1:J6v8awz+me+xeb/cUTotKgceAYouhIB3pjzgRd6IlGk=
 github.com/t-tomalak/logrus-easy-formatter v0.0.0-20190827215021-c074f06c5816/go.mod h1:tzym/CEb5jnFI+Q0k4Qq3+LvRF4gO3E2pxS8fHP8jcA=
-github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20240910231830-cdba4214092b h1:zHdbakF62w4cA/V4oMfV37W/u3nWwRNG82/EIrSrHMs=
-github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20240910231830-cdba4214092b/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
 github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20240925202023-da1620747493 h1:MAJZvwCT5Jl2zoW+QoZZg6lXj2YXytMOFn2MuwQzyQQ=
 github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20240925202023-da1620747493/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1658,7 +1658,7 @@ func (a *AuthApiClient) RemoveDbQueryLoggingConfig(clusterId string, exporterCon
 func (authApi *AuthApiClient) GetIntegrationIdFromName(integrationName string) (string, error) {
 	integration, _, err := authApi.ListIntegrations().Name(integrationName).Execute()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to get integration by name %s: %w", integrationName, err)
 	}
 
 	integrationData := integration.GetData()

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1627,3 +1627,18 @@ func (a *AuthApiClient) EditDbQueryLoggingConfig(clusterId string, exporterConfi
 func (a *AuthApiClient) RemoveDbQueryLoggingConfig(clusterId string, exporterConfigId string) ybmclient.ApiRemovePgLogExporterConfigRequest {
 	return a.ApiClient.ClusterApi.RemovePgLogExporterConfig(a.ctx, a.AccountID, a.ProjectID, clusterId, exporterConfigId)
 }
+
+func (authApi *AuthApiClient) GetIntegrationIdFromName(integrationName string) (string, error) {
+	integration, _, err := authApi.ListIntegrations().Name(integrationName).Execute()
+	if err != nil {
+		return "", err
+	}
+
+	integrationData := integration.GetData()
+
+	if len(integrationData) == 0 {
+		return "", fmt.Errorf("no integrations found with name: %s%s", integrationName, "\n")
+	}
+
+	return integrationData[0].GetInfo().Id, nil
+}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1611,3 +1611,19 @@ func (a *AuthApiClient) DeletePitrConfig(clusterId string, pitrConfigId string) 
 func (a *AuthApiClient) PerformConnectionPoolingOperation(clusterId string) ybmclient.ApiPerformConnectionPoolingOperationRequest {
 	return a.ApiClient.ClusterApi.PerformConnectionPoolingOperation(a.ctx, a.AccountID, a.ProjectID, clusterId)
 }
+
+func (a *AuthApiClient) GetDbLoggingConfig(clusterId string) ybmclient.ApiListPgLogExporterConfigsRequest {
+	return a.ApiClient.ClusterApi.ListPgLogExporterConfigs(a.ctx, a.AccountID, a.ProjectID, clusterId)
+}
+
+func (a *AuthApiClient) EnableDbQueryLogging(clusterId string) ybmclient.ApiAssociatePgLogExporterConfigRequest {
+	return a.ApiClient.ClusterApi.AssociatePgLogExporterConfig(a.ctx, a.AccountID, a.ProjectID, clusterId)
+}
+
+func (a *AuthApiClient) EditDbQueryLoggingConfig(clusterId string, exporterConfigId string) ybmclient.ApiUpdatePgLogExporterConfigRequest {
+	return a.ApiClient.ClusterApi.UpdatePgLogExporterConfig(a.ctx, a.AccountID, a.ProjectID, clusterId, exporterConfigId)
+}
+
+func (a *AuthApiClient) RemoveDbQueryLoggingConfig(clusterId string, exporterConfigId string) ybmclient.ApiRemovePgLogExporterConfigRequest {
+	return a.ApiClient.ClusterApi.RemovePgLogExporterConfig(a.ctx, a.AccountID, a.ProjectID, clusterId, exporterConfigId)
+}

--- a/internal/formatter/db_query_log_exporter.go
+++ b/internal/formatter/db_query_log_exporter.go
@@ -22,7 +22,7 @@ import (
 	ybmclient "github.com/yugabyte/yugabytedb-managed-go-client-internal"
 )
 
-const defaultDbQueryLoggingConfigListing = "table {{.State}}\t{{.ExporterID}}\t{{.LogConfig}}"
+const defaultDbQueryLoggingConfigListing = "table {{.State}}\t{{.IntegrationID}}\t{{.LogConfig}}"
 
 type DbQueryLoggingContext struct {
 	HeaderContext
@@ -37,9 +37,9 @@ func NewDbQueryLoggingFormat() Format {
 func NewDbQueryLoggingContext() *DbQueryLoggingContext {
 	DbQueryLoggingContext := DbQueryLoggingContext{}
 	DbQueryLoggingContext.Header = SubHeaderContext{
-		"State":      "State",
-		"ExporterID": "Exporter ID",
-		"LogConfig":  "Log Config",
+		"State":         "State",
+		"IntegrationID": "Integration ID",
+		"LogConfig":     "Log Config",
 	}
 	return &DbQueryLoggingContext
 }
@@ -62,7 +62,7 @@ func (context *DbQueryLoggingContext) State() string {
 	return string(context.data.Info.State)
 }
 
-func (context *DbQueryLoggingContext) ExporterID() string {
+func (context *DbQueryLoggingContext) IntegrationID() string {
 	return string(context.data.Spec.ExporterId)
 }
 

--- a/internal/formatter/db_query_log_exporter.go
+++ b/internal/formatter/db_query_log_exporter.go
@@ -1,0 +1,79 @@
+// Licensed to Yugabyte, Inc. under one or more contributor license
+// agreements. See the NOTICE file distributed with this work for
+// additional information regarding copyright ownership. Yugabyte
+// licenses this file to you under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package formatter
+
+import (
+	"encoding/json"
+
+	"github.com/sirupsen/logrus"
+	ybmclient "github.com/yugabyte/yugabytedb-managed-go-client-internal"
+)
+
+const defaultDbQueryLoggingConfigListing = "table {{.State}}\t{{.ExporterID}}\t{{.LogConfig}}"
+
+type DbQueryLoggingContext struct {
+	HeaderContext
+	Context
+	data ybmclient.PgLogExporterConfigData
+}
+
+func NewDbQueryLoggingFormat() Format {
+	return Format(defaultDbQueryLoggingConfigListing)
+}
+
+func NewDbQueryLoggingContext() *DbQueryLoggingContext {
+	DbQueryLoggingContext := DbQueryLoggingContext{}
+	DbQueryLoggingContext.Header = SubHeaderContext{
+		"State":      "State",
+		"ExporterID": "Exporter ID",
+		"LogConfig":  "Log Config",
+	}
+	return &DbQueryLoggingContext
+}
+
+func DbQueryLoggingWrite(ctx Context, PgLogExporterConfigData []ybmclient.PgLogExporterConfigData) error {
+	render := func(format func(subContext SubContext) error) error {
+		for _, data := range PgLogExporterConfigData {
+			err := format(&DbQueryLoggingContext{data: data})
+			if err != nil {
+				logrus.Debugf("Error rendering Pg Log Exporter config data: %v", err)
+				return err
+			}
+		}
+		return nil
+	}
+	return ctx.Write(NewDbQueryLoggingContext(), render)
+}
+
+func (context *DbQueryLoggingContext) State() string {
+	return string(context.data.Info.State)
+}
+
+func (context *DbQueryLoggingContext) ExporterID() string {
+	return string(context.data.Spec.ExporterId)
+}
+
+func (context *DbQueryLoggingContext) LogConfig() string {
+	x := context.data.GetSpec()
+	y := x.GetExportConfig()
+
+	return convertPgLogConfigToJson(&y)
+}
+
+func convertPgLogConfigToJson(cfg *ybmclient.PgLogExportConfig) string {
+	jsonConfig, _ := json.Marshal(cfg)
+	return string(jsonConfig)
+}


### PR DESCRIPTION
### Description:
Added support for DB Query logs exporter(https://docs.yugabyte.com/preview/yugabyte-cloud/cloud-monitor/logging-export/)

### Changelog:
- Added support for 4 subcommands for db query logging:
    - Enable logging
    - Disable logging
    - Describe config
    - Update logging config
- Added unit test for all commands

### CLI logs:

#### Enabling query log exporter
```shell
~/Developer/ybm-cli on feat/db_query_log_exporter                                                                                                       took 4s at 12:21:08
> make build && ./ybm cluster db-query-logging enable \
--cluster-name "bhupendray-cluster" \
--integration-name bhupendray-datadog-logging \
--log-line-prefix "%m :%r :%u @ %d :[%p] : %a :" \
--log-min-duration-statement 30 \
--log-connections true \
--log-duration false \
--log-error-verbosity DEFAULT \
--log-statement MOD
go build -ldflags="-X 'main.version=v0.1.0'" -o ybm
A newer version is available. Please upgrade to the latest version v0.1.20
State      Integration ID                            Log Config
ENABLING   7eb1b884-600e-4a91-a92c-9ee79b754e11   {"debug_print_plan":false,"log_connections":true,"log_disconnections":false,"log_duration":false,"log_error_verbosity":"DEFAULT","log_line_prefix":"%m :%r :%u @ %d :[%p] : %a :","log_min_duration_statement":30,"log_min_error_statement":"ERROR","log_statement":"MOD"}

```

#### Describe log exporter config:
```shell
~/Developer/ybm-cli on feat/db_query_log_exporter                                                                                                       took 7s at 12:09:00
> make build && ./ybm cluster db-query-logging describe --cluster-name "bhupendray-cluster"
go build -ldflags="-X 'main.version=v0.1.0'" -o ybm
A newer version is available. Please upgrade to the latest version v0.1.20
State       Integration ID                            Log Config
DISABLING   7eb1b884-600e-4a91-a92c-9ee79b754e11   {"debug_print_plan":false,"log_connections":true,"log_disconnections":false,"log_duration":false,"log_error_verbosity":"DEFAULT","log_line_prefix":"%m :%r :%u @ %d :[%p] : %a :","log_min_duration_statement":30,"log_min_error_statement":"ERROR","log_statement":"MOD"}

```

#### Disable query logs:
```bash
~/Developer/ybm-cli on feat/db_query_log_exporter                                                                                                           INT at 12:08:37
> make build && ./ybm cluster db-query-logging disable \
--cluster-name "bhupendray-cluster"
go build -ldflags="-X 'main.version=v0.1.0'" -o ybm
A newer version is available. Please upgrade to the latest version v0.1.20
Disabling DB query log config for the cluster, this may take a few minutes...
You can check the status via $ ybm cluster db-query-log-exporter describe --cluster-name bhupendray-cluster
```

#### Edit log exporter config:
```shell
~/Developer/ybm-cli on feat/db_query_log_exporter                                                                                                       took 5s at 11:19:37
> make build && ./ybm cluster db-query-logging update-config \
--cluster-name "bhupendray-cluster" \
--integration-name bhupendray-datadog-logging \
--log-line-prefix "%m :%r :%u @ %d :[%p] :" \
--log-min-duration-statement 60 \
--log-connections false \
--log-duration true \
--log-error-verbosity DEFAULT \
--log-statement ALL
go build -ldflags="-X 'main.version=v0.1.0'" -o ybm
A newer version is available. Please upgrade to the latest version v0.1.20
State     Integration ID                            Log Config
ACTIVE    7eb1b884-600e-4a91-a92c-9ee79b754e11  {"debug_print_plan":false,"log_connections":false,"log_disconnections":false,"log_duration":true,"log_error_verbosity":"DEFAULT","log_line_prefix":"%m :%r :%u @ %d :[%p] :","log_min_duration_statement":60,"log_min_error_statement":"ERROR","log_statement":"ALL"}
```