### PR TITLE
Redesign DR commands to be more meaningful

### DIFF
--- a/cmd/dr/config/config.go
+++ b/cmd/dr/config/config.go
@@ -13,22 +13,21 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package dr
+package config
 
 import (
 	"github.com/spf13/cobra"
-	"github.com/yugabyte/ybm-cli/cmd/dr/config"
 )
 
-var DrCmd = &cobra.Command{
-	Use:   "dr",
-	Short: "Manage DR for a cluster.",
-	Long:  "Manage DR for a cluster.",
+var ConfigCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Manage DR config",
+	Long:  "Manage DR config",
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()
 	},
 }
 
 func init() {
-	DrCmd.AddCommand(config.ConfigCmd)
+	ConfigCmd.AddCommand()
 }

--- a/cmd/dr/config/delete_dr.go
+++ b/cmd/dr/config/delete_dr.go
@@ -13,23 +13,33 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package dr
+package config
 
 import (
-	"os"
+	"fmt"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"github.com/yugabyte/ybm-cli/cmd/util"
 	ybmAuthClient "github.com/yugabyte/ybm-cli/internal/client"
 	"github.com/yugabyte/ybm-cli/internal/formatter"
 	ybmclient "github.com/yugabyte/yugabytedb-managed-go-client-internal"
 )
 
-var describeDrCmd = &cobra.Command{
-	Use:   "describe",
-	Short: "Describe DR",
-	Long:  `Describe DR`,
+var deleteDrCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete DR",
+	Long:  `Delete DR`,
+	PreRun: func(cmd *cobra.Command, args []string) {
+		viper.BindPFlag("force", cmd.Flags().Lookup("force"))
+		drName, _ := cmd.Flags().GetString("config")
+		msg := fmt.Sprintf("Are you sure you want to delete dr: %s", drName)
+		err := util.ConfirmCommand(msg, viper.GetBool("force"))
+		if err != nil {
+			logrus.Fatal(err)
+		}
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		authApi, err := ybmAuthClient.NewAuthApiClient()
 		if err != nil {
@@ -37,9 +47,9 @@ var describeDrCmd = &cobra.Command{
 		}
 		authApi.GetInfo("", "")
 
-		drName, _ := cmd.Flags().GetString("dr-name")
+		drName, _ := cmd.Flags().GetString("config")
 		if err != nil {
-			logrus.Fatalf("Could not get cluster data: %s", ybmAuthClient.GetApiErrorDetails(err))
+			logrus.Fatal(err)
 		}
 		drInfo, err := authApi.GetDrDetailsByName(drName)
 		if err != nil {
@@ -47,23 +57,33 @@ var describeDrCmd = &cobra.Command{
 		}
 		drId := drInfo.GetId()
 		clusterId := drInfo.GetSourceClusterId()
-		drResp, r, err := authApi.GetXClusterDr(clusterId, drId).Execute()
+
+		r, err := authApi.DeleteXClusterDr(clusterId, drId).Execute()
 		if err != nil {
 			logrus.Debugf("Full HTTP response: %v", r)
 			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 
-		drCtx := formatter.Context{
-			Output: os.Stdout,
-			Format: formatter.NewDrFormat(viper.GetString("output")),
-		}
+		msg := fmt.Sprintf("The DR %s is being deleted", formatter.Colorize(drName, formatter.GREEN_COLOR))
 
-		formatter.DrWrite(drCtx, []ybmclient.XClusterDrData{drResp.GetData()}, *authApi)
+		if viper.GetBool("wait") {
+			returnStatus, err := authApi.WaitForTaskCompletion(clusterId, ybmclient.ENTITYTYPEENUM_CLUSTER, ybmclient.TASKTYPEENUM_DELETE_DR, []string{"FAILED", "SUCCEEDED"}, msg)
+			if err != nil {
+				logrus.Fatalf("error when getting task status: %s", err)
+			}
+			if returnStatus != "SUCCEEDED" {
+				logrus.Fatalf("Operation failed with error: %s", returnStatus)
+			}
+			fmt.Printf("The DR %s has been deleted\n", formatter.Colorize(drName, formatter.GREEN_COLOR))
+			return
+		}
+		fmt.Println(msg)
 	},
 }
 
 func init() {
-	DrCmd.AddCommand(describeDrCmd)
-	describeDrCmd.Flags().String("dr-name", "", "[REQUIRED] Name of the DR configuration.")
-	describeDrCmd.MarkFlagRequired("dr-name")
+	ConfigCmd.AddCommand(deleteDrCmd)
+	deleteDrCmd.Flags().String("config", "", "[REQUIRED] Name of the DR configuration")
+	deleteDrCmd.MarkFlagRequired("config")
+
 }

--- a/cmd/dr/config/describe_dr.go
+++ b/cmd/dr/config/describe_dr.go
@@ -13,33 +13,23 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package dr
+package config
 
 import (
-	"fmt"
+	"os"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/yugabyte/ybm-cli/cmd/util"
 	ybmAuthClient "github.com/yugabyte/ybm-cli/internal/client"
 	"github.com/yugabyte/ybm-cli/internal/formatter"
 	ybmclient "github.com/yugabyte/yugabytedb-managed-go-client-internal"
 )
 
-var deleteDrCmd = &cobra.Command{
-	Use:   "delete",
-	Short: "Delete DR",
-	Long:  `Delete DR`,
-	PreRun: func(cmd *cobra.Command, args []string) {
-		viper.BindPFlag("force", cmd.Flags().Lookup("force"))
-		drName, _ := cmd.Flags().GetString("dr-name")
-		msg := fmt.Sprintf("Are you sure you want to delete dr: %s", drName)
-		err := util.ConfirmCommand(msg, viper.GetBool("force"))
-		if err != nil {
-			logrus.Fatal(err)
-		}
-	},
+var describeDrCmd = &cobra.Command{
+	Use:   "describe",
+	Short: "Describe DR",
+	Long:  `Describe DR`,
 	Run: func(cmd *cobra.Command, args []string) {
 		authApi, err := ybmAuthClient.NewAuthApiClient()
 		if err != nil {
@@ -47,9 +37,9 @@ var deleteDrCmd = &cobra.Command{
 		}
 		authApi.GetInfo("", "")
 
-		drName, _ := cmd.Flags().GetString("dr-name")
+		drName, _ := cmd.Flags().GetString("config")
 		if err != nil {
-			logrus.Fatal(err)
+			logrus.Fatalf("Could not get cluster data: %s", ybmAuthClient.GetApiErrorDetails(err))
 		}
 		drInfo, err := authApi.GetDrDetailsByName(drName)
 		if err != nil {
@@ -57,33 +47,23 @@ var deleteDrCmd = &cobra.Command{
 		}
 		drId := drInfo.GetId()
 		clusterId := drInfo.GetSourceClusterId()
-
-		r, err := authApi.DeleteXClusterDr(clusterId, drId).Execute()
+		drResp, r, err := authApi.GetXClusterDr(clusterId, drId).Execute()
 		if err != nil {
 			logrus.Debugf("Full HTTP response: %v", r)
 			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
 
-		msg := fmt.Sprintf("The DR %s is being deleted", formatter.Colorize(drName, formatter.GREEN_COLOR))
-
-		if viper.GetBool("wait") {
-			returnStatus, err := authApi.WaitForTaskCompletion(clusterId, ybmclient.ENTITYTYPEENUM_CLUSTER, ybmclient.TASKTYPEENUM_DELETE_DR, []string{"FAILED", "SUCCEEDED"}, msg)
-			if err != nil {
-				logrus.Fatalf("error when getting task status: %s", err)
-			}
-			if returnStatus != "SUCCEEDED" {
-				logrus.Fatalf("Operation failed with error: %s", returnStatus)
-			}
-			fmt.Printf("The DR %s has been deleted\n", formatter.Colorize(drName, formatter.GREEN_COLOR))
-			return
+		drCtx := formatter.Context{
+			Output: os.Stdout,
+			Format: formatter.NewDrFormat(viper.GetString("output")),
 		}
-		fmt.Println(msg)
+
+		formatter.DrWrite(drCtx, []ybmclient.XClusterDrData{drResp.GetData()}, *authApi)
 	},
 }
 
 func init() {
-	DrCmd.AddCommand(deleteDrCmd)
-	deleteDrCmd.Flags().String("dr-name", "", "[REQUIRED] Name of the DR configuration")
-	deleteDrCmd.MarkFlagRequired("dr-name")
-
+	ConfigCmd.AddCommand(describeDrCmd)
+	describeDrCmd.Flags().String("config", "", "[REQUIRED] Name of the DR configuration.")
+	describeDrCmd.MarkFlagRequired("config")
 }

--- a/cmd/dr/config/list_dr.go
+++ b/cmd/dr/config/list_dr.go
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package dr
+package config
 
 import (
 	"fmt"
@@ -59,5 +59,5 @@ var listDrCmd = &cobra.Command{
 }
 
 func init() {
-	DrCmd.AddCommand(listDrCmd)
+	ConfigCmd.AddCommand(listDrCmd)
 }

--- a/cmd/dr/config/update_dr.go
+++ b/cmd/dr/config/update_dr.go
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package dr
+package config
 
 import (
 	"fmt"
@@ -28,10 +28,10 @@ import (
 	ybmclient "github.com/yugabyte/yugabytedb-managed-go-client-internal"
 )
 
-var createDrCmd = &cobra.Command{
-	Use:   "create",
-	Short: "Create DR for a cluster",
-	Long:  `Create DR for a cluster`,
+var updateDrCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update DR for a cluster",
+	Long:  `Update DR for a cluster`,
 	Run: func(cmd *cobra.Command, args []string) {
 		authApi, err := ybmAuthClient.NewAuthApiClient()
 		if err != nil {
@@ -39,19 +39,18 @@ var createDrCmd = &cobra.Command{
 		}
 		authApi.GetInfo("", "")
 
-		drName, _ := cmd.Flags().GetString("dr-name")
-		sourceClusterName, _ := cmd.Flags().GetString("source-cluster-name")
-		targetClusterName, _ := cmd.Flags().GetString("target-cluster-name")
+		drName, _ := cmd.Flags().GetString("config")
 		databases, _ := cmd.Flags().GetStringArray("databases")
-		sourceClusterId, err := authApi.GetClusterIdByName(sourceClusterName)
 		if err != nil {
 			logrus.Fatalf("Could not get cluster data: %s", ybmAuthClient.GetApiErrorDetails(err))
 		}
-		targetClusterId, err := authApi.GetClusterIdByName(targetClusterName)
+		drInfo, err := authApi.GetDrDetailsByName(drName)
 		if err != nil {
-			logrus.Fatalf("Could not get cluster data: %s", ybmAuthClient.GetApiErrorDetails(err))
+			logrus.Fatal(err)
 		}
-		namespacesResp, r, err := authApi.GetClusterNamespaces(sourceClusterId).Execute()
+		drId := drInfo.GetId()
+		clusterId := drInfo.GetSourceClusterId()
+		namespacesResp, r, err := authApi.GetClusterNamespaces(clusterId).Execute()
 		if err != nil {
 			logrus.Debugf("Full HTTP response: %v", r)
 			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
@@ -70,27 +69,27 @@ var createDrCmd = &cobra.Command{
 				}
 			}
 		}
-		createDrRequest := ybmclient.NewCreateXClusterDrRequest(*ybmclient.NewXClusterDrSpec(drName, targetClusterId, databaseIds))
-		drResp, response, err := authApi.CreateXClusterDr(sourceClusterId).CreateXClusterDrRequest(*createDrRequest).Execute()
+
+		updateDrRequest := ybmclient.NewEditXClusterDrRequest(*ybmclient.NewEditXClusterDrSpec(databaseIds))
+		drResp, response, err := authApi.EditXClusterDr(clusterId, drId).EditXClusterDrRequest(*updateDrRequest).Execute()
 		if err != nil {
 			logrus.Debugf("Full HTTP response: %v", response)
 			logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
 		}
-		drId := drResp.GetData().Info.Id
 
-		msg := fmt.Sprintf("The DR %s is being created", formatter.Colorize(drName, formatter.GREEN_COLOR))
+		msg := fmt.Sprintf("DR config %s is being updated", formatter.Colorize(drName, formatter.GREEN_COLOR))
 
 		if viper.GetBool("wait") {
-			returnStatus, err := authApi.WaitForTaskCompletion(sourceClusterId, ybmclient.ENTITYTYPEENUM_CLUSTER, ybmclient.TASKTYPEENUM_CREATE_DR, []string{"FAILED", "SUCCEEDED"}, msg)
+			returnStatus, err := authApi.WaitForTaskCompletion(clusterId, ybmclient.ENTITYTYPEENUM_CLUSTER, ybmclient.TASKTYPEENUM_EDIT_DR, []string{"FAILED", "SUCCEEDED"}, msg)
 			if err != nil {
 				logrus.Fatalf("error when getting task status: %s", err)
 			}
 			if returnStatus != "SUCCEEDED" {
 				logrus.Fatalf("Operation failed with error: %s", returnStatus)
 			}
-			fmt.Printf("The DR %s has been created\n", formatter.Colorize(drName, formatter.GREEN_COLOR))
+			fmt.Printf("DR config %s has been updated\n", formatter.Colorize(drName, formatter.GREEN_COLOR))
 
-			drGetResp, r, err := authApi.GetXClusterDr(sourceClusterId, drId).Execute()
+			drGetResp, r, err := authApi.GetXClusterDr(clusterId, drId).Execute()
 			if err != nil {
 				logrus.Debugf("Full HTTP response: %v", r)
 				logrus.Fatalf(ybmAuthClient.GetApiErrorDetails(err))
@@ -111,13 +110,9 @@ var createDrCmd = &cobra.Command{
 }
 
 func init() {
-	DrCmd.AddCommand(createDrCmd)
-	createDrCmd.Flags().String("dr-name", "", "[REQUIRED] Name of the DR configuration.")
-	createDrCmd.MarkFlagRequired("dr-name")
-	createDrCmd.Flags().String("source-cluster-name", "", "[REQUIRED] Source cluster in the DR configuration.")
-	createDrCmd.MarkFlagRequired("source-cluster-name")
-	createDrCmd.Flags().String("target-cluster-name", "", "[REQUIRED] Target cluster in the DR configuration.")
-	createDrCmd.MarkFlagRequired("target-cluster-name")
-	createDrCmd.Flags().StringArray("databases", []string{}, "[REQUIRED] Databases to be replicated. Please provide a comma separated list of database names <db-name-1>,<db-name-2>.")
-	createDrCmd.MarkFlagRequired("databases")
+	ConfigCmd.AddCommand(updateDrCmd)
+	updateDrCmd.Flags().String("config", "", "[REQUIRED] Name of the DR configuration.")
+	updateDrCmd.MarkFlagRequired("config")
+	updateDrCmd.Flags().StringArray("databases", []string{}, "[REQUIRED] Databases to be replicated. Please provide a comma separated list of database names <db-name-1>,<db-name-2>.")
+	updateDrCmd.MarkFlagRequired("databases")
 }

--- a/cmd/dr/failover_dr.go
+++ b/cmd/dr/failover_dr.go
@@ -40,7 +40,7 @@ var failoverDrCmd = &cobra.Command{
 		}
 		authApi.GetInfo("", "")
 
-		drName, _ := cmd.Flags().GetString("dr-name")
+		drName, _ := cmd.Flags().GetString("config")
 		safetimes, _ := cmd.Flags().GetStringArray("safetimes")
 		if err != nil {
 			logrus.Fatalf("Could not get cluster data: %s", ybmAuthClient.GetApiErrorDetails(err))
@@ -125,7 +125,7 @@ var failoverDrCmd = &cobra.Command{
 
 func init() {
 	DrCmd.AddCommand(failoverDrCmd)
-	failoverDrCmd.Flags().String("dr-name", "", "[REQUIRED] Name of the DR configuration.")
-	failoverDrCmd.MarkFlagRequired("dr-name")
+	failoverDrCmd.Flags().String("config", "", "[REQUIRED] Name of the DR configuration.")
+	failoverDrCmd.MarkFlagRequired("config")
 	failoverDrCmd.Flags().StringArray("safetimes", []string{}, "[OPTIONAL] Safetimes of the DR configuation.  Please provide key value pairs <db-name-1>=<epoch-safe-time>,<db-name-2>=<epoch-safe-time>.")
 }

--- a/cmd/dr/pause_dr.go
+++ b/cmd/dr/pause_dr.go
@@ -38,7 +38,7 @@ var pauseDrCmd = &cobra.Command{
 		}
 		authApi.GetInfo("", "")
 
-		drName, _ := cmd.Flags().GetString("dr-name")
+		drName, _ := cmd.Flags().GetString("config")
 		durationInMin, _ := cmd.Flags().GetInt32("duration")
 		if err != nil {
 			logrus.Fatalf("Could not get cluster data: %s", ybmAuthClient.GetApiErrorDetails(err))
@@ -90,7 +90,7 @@ var pauseDrCmd = &cobra.Command{
 
 func init() {
 	DrCmd.AddCommand(pauseDrCmd)
-	pauseDrCmd.Flags().String("dr-name", "", "[REQUIRED] Name of the DR configuration.")
-	pauseDrCmd.MarkFlagRequired("dr-name")
+	pauseDrCmd.Flags().String("config", "", "[REQUIRED] Name of the DR configuration.")
+	pauseDrCmd.MarkFlagRequired("config")
 	pauseDrCmd.Flags().Int32("duration", 60, "[OPTIONAL] Duration in minutes.")
 }

--- a/cmd/dr/restart_dr.go
+++ b/cmd/dr/restart_dr.go
@@ -39,7 +39,7 @@ var restartDrCmd = &cobra.Command{
 		}
 		authApi.GetInfo("", "")
 
-		drName, _ := cmd.Flags().GetString("dr-name")
+		drName, _ := cmd.Flags().GetString("config")
 		databases, _ := cmd.Flags().GetStringArray("databases")
 		if err != nil {
 			logrus.Fatalf("Could not get cluster data: %s", ybmAuthClient.GetApiErrorDetails(err))
@@ -111,7 +111,7 @@ var restartDrCmd = &cobra.Command{
 
 func init() {
 	DrCmd.AddCommand(restartDrCmd)
-	restartDrCmd.Flags().String("dr-name", "", "[REQUIRED] Name of the DR configuration.")
-	restartDrCmd.MarkFlagRequired("dr-name")
+	restartDrCmd.Flags().String("config", "", "[REQUIRED] Name of the DR configuration.")
+	restartDrCmd.MarkFlagRequired("config")
 	restartDrCmd.Flags().StringArray("databases", []string{}, "[OPTIONAL] Databases to be restarted. Please provide a comma separated list of database names <db-name-1>,<db-name-2>.")
 }

--- a/cmd/dr/resume_dr.go
+++ b/cmd/dr/resume_dr.go
@@ -38,7 +38,7 @@ var resumeDrCmd = &cobra.Command{
 		}
 		authApi.GetInfo("", "")
 
-		drName, _ := cmd.Flags().GetString("dr-name")
+		drName, _ := cmd.Flags().GetString("config")
 		if err != nil {
 			logrus.Fatalf("Could not get cluster data: %s", ybmAuthClient.GetApiErrorDetails(err))
 		}
@@ -87,6 +87,6 @@ var resumeDrCmd = &cobra.Command{
 
 func init() {
 	DrCmd.AddCommand(resumeDrCmd)
-	resumeDrCmd.Flags().String("dr-name", "", "[REQUIRED] Name of the DR configuration.")
-	resumeDrCmd.MarkFlagRequired("dr-name")
+	resumeDrCmd.Flags().String("config", "", "[REQUIRED] Name of the DR configuration.")
+	resumeDrCmd.MarkFlagRequired("config")
 }

--- a/cmd/dr/switchover_dr.go
+++ b/cmd/dr/switchover_dr.go
@@ -38,7 +38,7 @@ var switchoverDrCmd = &cobra.Command{
 		}
 		authApi.GetInfo("", "")
 
-		drName, _ := cmd.Flags().GetString("dr-name")
+		drName, _ := cmd.Flags().GetString("config")
 		if err != nil {
 			logrus.Fatalf("Could not get cluster data: %s", ybmAuthClient.GetApiErrorDetails(err))
 		}
@@ -87,6 +87,6 @@ var switchoverDrCmd = &cobra.Command{
 
 func init() {
 	DrCmd.AddCommand(switchoverDrCmd)
-	switchoverDrCmd.Flags().String("dr-name", "", "[REQUIRED] Name of the DR configuration.")
-	switchoverDrCmd.MarkFlagRequired("dr-name")
+	switchoverDrCmd.Flags().String("config", "", "[REQUIRED] Name of the DR configuration.")
+	switchoverDrCmd.MarkFlagRequired("config")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -43,7 +43,6 @@ import (
 	"github.com/yugabyte/ybm-cli/cmd/vpc"
 
 	"github.com/yugabyte/ybm-cli/internal/log"
-	"github.com/yugabyte/ybm-cli/internal/releases"
 )
 
 var (
@@ -66,7 +65,7 @@ var rootCmd = &cobra.Command{
 		if strings.HasPrefix(cmd.CommandPath(), "ybm completion") {
 			return
 		}
-		releases.PrintUpgradeMessageIfNeeded()
+		//releases.PrintUpgradeMessageIfNeeded()
 
 	},
 }

--- a/docs/ybm_dr.md
+++ b/docs/ybm_dr.md
@@ -32,14 +32,10 @@ ybm dr [flags]
 ### SEE ALSO
 
 * [ybm](ybm.md)	 - ybm - Effortlessly manage your DB infrastructure on YugabyteDB Aeon (DBaaS) from command line!
-* [ybm dr create](ybm_dr_create.md)	 - Create DR for a cluster
-* [ybm dr delete](ybm_dr_delete.md)	 - Delete DR
-* [ybm dr describe](ybm_dr_describe.md)	 - Describe DR
+* [ybm dr config](ybm_dr_config.md)	 - Manage DR config
 * [ybm dr failover](ybm_dr_failover.md)	 - Failover DR for a cluster
-* [ybm dr list](ybm_dr_list.md)	 - List DRs for a given cluster
 * [ybm dr pause](ybm_dr_pause.md)	 - Pause DR for a cluster
 * [ybm dr restart](ybm_dr_restart.md)	 - Restart DR for a cluster
 * [ybm dr resume](ybm_dr_resume.md)	 - Resume DR for a cluster
 * [ybm dr switchover](ybm_dr_switchover.md)	 - Switchover DR for a cluster
-* [ybm dr update](ybm_dr_update.md)	 - Update DR for a cluster
 

--- a/docs/ybm_dr_config.md
+++ b/docs/ybm_dr_config.md
@@ -1,20 +1,19 @@
-## ybm dr describe
+## ybm dr config
 
-Describe DR
+Manage DR config
 
 ### Synopsis
 
-Describe DR
+Manage DR config
 
 ```
-ybm dr describe [flags]
+ybm dr config [flags]
 ```
 
 ### Options
 
 ```
-      --dr-name string   [REQUIRED] Name of the DR configuration.
-  -h, --help             help for describe
+  -h, --help   help for config
 ```
 
 ### Options inherited from parent commands
@@ -33,4 +32,9 @@ ybm dr describe [flags]
 ### SEE ALSO
 
 * [ybm dr](ybm_dr.md)	 - Manage DR for a cluster.
+* [ybm dr config create](ybm_dr_config_create.md)	 - Create DR for a cluster
+* [ybm dr config delete](ybm_dr_config_delete.md)	 - Delete DR
+* [ybm dr config describe](ybm_dr_config_describe.md)	 - Describe DR
+* [ybm dr config list](ybm_dr_config_list.md)	 - List DRs for a given cluster
+* [ybm dr config update](ybm_dr_config_update.md)	 - Update DR for a cluster
 

--- a/docs/ybm_dr_config_create.md
+++ b/docs/ybm_dr_config_create.md
@@ -1,4 +1,4 @@
-## ybm dr create
+## ybm dr config create
 
 Create DR for a cluster
 
@@ -7,17 +7,17 @@ Create DR for a cluster
 Create DR for a cluster
 
 ```
-ybm dr create [flags]
+ybm dr config create [flags]
 ```
 
 ### Options
 
 ```
-      --databases stringArray        [REQUIRED] Databases to be replicated. Please provide a comma separated list of database names <db-name-1>,<db-name-2>.
-      --dr-name string               [REQUIRED] Name of the DR configuration.
-  -h, --help                         help for create
-      --source-cluster-name string   [REQUIRED] Source cluster in the DR configuration.
-      --target-cluster-name string   [REQUIRED] Target cluster in the DR configuration.
+      --databases stringArray   [REQUIRED] Databases to be replicated. Please provide a comma separated list of database names <db-name-1>,<db-name-2>.
+  -h, --help                    help for create
+      --name string             [REQUIRED] Name of the DR configuration.
+      --source-cluster string   [REQUIRED] Source cluster in the DR configuration.
+      --target-cluster string   [REQUIRED] Target cluster in the DR configuration.
 ```
 
 ### Options inherited from parent commands
@@ -35,5 +35,5 @@ ybm dr create [flags]
 
 ### SEE ALSO
 
-* [ybm dr](ybm_dr.md)	 - Manage DR for a cluster.
+* [ybm dr config](ybm_dr_config.md)	 - Manage DR config
 

--- a/docs/ybm_dr_config_delete.md
+++ b/docs/ybm_dr_config_delete.md
@@ -1,4 +1,4 @@
-## ybm dr delete
+## ybm dr config delete
 
 Delete DR
 
@@ -7,21 +7,20 @@ Delete DR
 Delete DR
 
 ```
-ybm dr delete [flags]
+ybm dr config delete [flags]
 ```
 
 ### Options
 
 ```
-      --dr-name string   [REQUIRED] Name of the DR configuration
-  -h, --help             help for delete
+      --config string   [REQUIRED] Name of the DR configuration
+  -h, --help            help for delete
 ```
 
 ### Options inherited from parent commands
 
 ```
   -a, --apiKey string      YugabyteDB Aeon account API key
-      --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
@@ -32,5 +31,5 @@ ybm dr delete [flags]
 
 ### SEE ALSO
 
-* [ybm dr](ybm_dr.md)	 - Manage DR for a cluster.
+* [ybm dr config](ybm_dr_config.md)	 - Manage DR config
 

--- a/docs/ybm_dr_config_describe.md
+++ b/docs/ybm_dr_config_describe.md
@@ -1,28 +1,26 @@
-## ybm dr update
+## ybm dr config describe
 
-Update DR for a cluster
+Describe DR
 
 ### Synopsis
 
-Update DR for a cluster
+Describe DR
 
 ```
-ybm dr update [flags]
+ybm dr config describe [flags]
 ```
 
 ### Options
 
 ```
-      --databases stringArray   [REQUIRED] Databases to be replicated. Please provide a comma separated list of database names <db-name-1>,<db-name-2>.
-      --dr-name string          [REQUIRED] Name of the DR configuration.
-  -h, --help                    help for update
+      --config string   [REQUIRED] Name of the DR configuration.
+  -h, --help            help for describe
 ```
 
 ### Options inherited from parent commands
 
 ```
   -a, --apiKey string      YugabyteDB Aeon account API key
-      --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
@@ -33,5 +31,5 @@ ybm dr update [flags]
 
 ### SEE ALSO
 
-* [ybm dr](ybm_dr.md)	 - Manage DR for a cluster.
+* [ybm dr config](ybm_dr_config.md)	 - Manage DR config
 

--- a/docs/ybm_dr_config_list.md
+++ b/docs/ybm_dr_config_list.md
@@ -1,27 +1,26 @@
-## ybm dr restart
+## ybm dr config list
 
-Restart DR for a cluster
+List DRs for a given cluster
 
 ### Synopsis
 
-Restart DR for a cluster
+List DRs for a given cluster
 
 ```
-ybm dr restart [flags]
+ybm dr config list [flags]
 ```
 
 ### Options
 
 ```
-      --config string           [REQUIRED] Name of the DR configuration.
-      --databases stringArray   [OPTIONAL] Databases to be restarted. Please provide a comma separated list of database names <db-name-1>,<db-name-2>.
-  -h, --help                    help for restart
+  -h, --help   help for list
 ```
 
 ### Options inherited from parent commands
 
 ```
   -a, --apiKey string      YugabyteDB Aeon account API key
+      --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
@@ -32,5 +31,5 @@ ybm dr restart [flags]
 
 ### SEE ALSO
 
-* [ybm dr](ybm_dr.md)	 - Manage DR for a cluster.
+* [ybm dr config](ybm_dr_config.md)	 - Manage DR config
 

--- a/docs/ybm_dr_config_update.md
+++ b/docs/ybm_dr_config_update.md
@@ -1,26 +1,27 @@
-## ybm dr list
+## ybm dr config update
 
-List DRs for a given cluster
+Update DR for a cluster
 
 ### Synopsis
 
-List DRs for a given cluster
+Update DR for a cluster
 
 ```
-ybm dr list [flags]
+ybm dr config update [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for list
+      --config string           [REQUIRED] Name of the DR configuration.
+      --databases stringArray   [REQUIRED] Databases to be replicated. Please provide a comma separated list of database names <db-name-1>,<db-name-2>.
+  -h, --help                    help for update
 ```
 
 ### Options inherited from parent commands
 
 ```
   -a, --apiKey string      YugabyteDB Aeon account API key
-      --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
@@ -31,5 +32,5 @@ ybm dr list [flags]
 
 ### SEE ALSO
 
-* [ybm dr](ybm_dr.md)	 - Manage DR for a cluster.
+* [ybm dr config](ybm_dr_config.md)	 - Manage DR config
 

--- a/docs/ybm_dr_failover.md
+++ b/docs/ybm_dr_failover.md
@@ -13,7 +13,7 @@ ybm dr failover [flags]
 ### Options
 
 ```
-      --dr-name string          [REQUIRED] Name of the DR configuration.
+      --config string           [REQUIRED] Name of the DR configuration.
   -h, --help                    help for failover
       --safetimes stringArray   [OPTIONAL] Safetimes of the DR configuation.  Please provide key value pairs <db-name-1>=<epoch-safe-time>,<db-name-2>=<epoch-safe-time>.
 ```
@@ -22,7 +22,6 @@ ybm dr failover [flags]
 
 ```
   -a, --apiKey string      YugabyteDB Aeon account API key
-      --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false

--- a/docs/ybm_dr_pause.md
+++ b/docs/ybm_dr_pause.md
@@ -13,7 +13,7 @@ ybm dr pause [flags]
 ### Options
 
 ```
-      --dr-name string   [REQUIRED] Name of the DR configuration.
+      --config string    [REQUIRED] Name of the DR configuration.
       --duration int32   [OPTIONAL] Duration in minutes. (default 60)
   -h, --help             help for pause
 ```
@@ -22,7 +22,6 @@ ybm dr pause [flags]
 
 ```
   -a, --apiKey string      YugabyteDB Aeon account API key
-      --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false

--- a/docs/ybm_dr_resume.md
+++ b/docs/ybm_dr_resume.md
@@ -13,15 +13,14 @@ ybm dr resume [flags]
 ### Options
 
 ```
-      --dr-name string   [REQUIRED] Name of the DR configuration.
-  -h, --help             help for resume
+      --config string   [REQUIRED] Name of the DR configuration.
+  -h, --help            help for resume
 ```
 
 ### Options inherited from parent commands
 
 ```
   -a, --apiKey string      YugabyteDB Aeon account API key
-      --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false

--- a/docs/ybm_dr_switchover.md
+++ b/docs/ybm_dr_switchover.md
@@ -13,15 +13,14 @@ ybm dr switchover [flags]
 ### Options
 
 ```
-      --dr-name string   [REQUIRED] Name of the DR configuration.
-  -h, --help             help for switchover
+      --config string   [REQUIRED] Name of the DR configuration.
+  -h, --help            help for switchover
 ```
 
 ### Options inherited from parent commands
 
 ```
   -a, --apiKey string      YugabyteDB Aeon account API key
-      --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false


### PR DESCRIPTION
```
./ybm dr config create --name first-dr --source-cluster brilliant-partridge --target-cluster passionate-coyote --databases test1
./ybm dr config list
./ybm dr config describe --config first-dr
./ybm dr config delete --config first-dr
./ybm dr config update --config sample-config --databases test1,test2
./ybm dr switchover --config sample-config
./ybm dr failover --config sample-config-final-srinivas --safetimes test1=1729716937,test2=1729716937
./ybm dr restart --config sample-config-final-srinivas --databases test1,test2
./ybm dr pause --config sample-config-final-srinivas --duration 5
./ybm dr resume --config sample-config-final-srinivas
```