### PR TITLE
[CLOUDGA-20774] Add support for interation type PROMETHEUS

### DIFF
--- a/cmd/test/fixtures/metrics-exporter-prom.json
+++ b/cmd/test/fixtures/metrics-exporter-prom.json
@@ -1,0 +1,19 @@
+{
+    "data": {
+        "spec": {
+            "name": "test",
+            "type": "PROMETHEUS",
+            "prometheus_spec": {
+                "endpoint": "http://prometheus.yourcompany.com/api/v1/otlp"
+            }
+        },
+        "info": {
+            "id": "9e3fabbc-849c-4a77-bdb2-9422e712e7dc",
+            "cluster_ids": [],
+            "metadata": {
+                "created_on": "2023-08-24T06:41:16.145Z",
+                "updated_on": "2023-08-24T06:41:16.145Z"
+            }
+        }
+    }
+}

--- a/internal/formatter/telemetry_provider.go
+++ b/internal/formatter/telemetry_provider.go
@@ -25,6 +25,7 @@ import (
 
 const defaultIntegrationListing = "table {{.ID}}\t{{.Name}}\t{{.Type}}"
 const defaultIntegrationDataDog = "table {{.ID}}\t{{.Name}}\t{{.Type}}\t{{.Site}}\t{{.ApiKey}}"
+const defaultIntegrationPrometheus = "table {{.ID}}\t{{.Name}}\t{{.Type}}\t{{.Endpoint}}"
 const defaultIntegrationGrafana = "table {{.ID}}\t{{.Name}}\t{{.Type}}\t{{.Zone}}\t{{.AccessTokenPolicy}}\t{{.InstanceId}}\t{{.OrgSlug}}"
 const defaultIntegrationSumologic = "table {{.ID}}\t{{.Name}}\t{{.Type}}\t{{.AccessKey}}\t{{.AccessID}}\t{{.InstallationToken}}"
 
@@ -41,6 +42,8 @@ func NewIntegrationFormat(source string, providerType string) Format {
 	switch providerType {
 	case string(ybmclient.TELEMETRYPROVIDERTYPEENUM_DATADOG):
 		format = defaultIntegrationDataDog
+	case string(ybmclient.TELEMETRYPROVIDERTYPEENUM_PROMETHEUS):
+		format = defaultIntegrationPrometheus
 	case string(ybmclient.TELEMETRYPROVIDERTYPEENUM_GRAFANA):
 		format = defaultIntegrationGrafana
 	case string(ybmclient.TELEMETRYPROVIDERTYPEENUM_SUMOLOGIC):
@@ -70,6 +73,7 @@ func NewIntegrationContext() *IntegrationContext {
 		"InstallationToken": "InstallationToken",
 		"AccessID":          "Access ID",
 		"AccessKey":         "Access Key",
+		"Endpoint":          "Endpoint",
 	}
 	return &IntegrationCtx
 }
@@ -148,4 +152,9 @@ func IntegrationShortenKey(key string, stringLen int) string {
 		return fmt.Sprintf("%s%s%s", key[:12], "...", key[len(key)-17:])
 	}
 	return key
+}
+
+// Prometheus
+func (tp *IntegrationContext) Endpoint() string {
+	return tp.tp.Spec.GetPrometheusSpec().Endpoint
 }


### PR DESCRIPTION
### Create Integration
```shell
$ ./ybm integration create --config-name test --type prometheus \
--prometheus-spec endpoint=http://prometheus.yourcompany.com
go build -ldflags="-X 'main.version=v0.1.0'" -o ybm
The Integration test has been created
ID                                     Name      Type         Endpoint
ab1fdeea-1d2c-48ac-b44c-de8cc4c31b76   test      PROMETHEUS   http://prometheus.yourcompany.com/api/v1/otlp
```

### Delete Integration
```shell
$ ./ybm integration delete --config-name test
go build -ldflags="-X 'main.version=v0.1.0'" -o ybm
? Are you sure you want to delete config: test Yes
The Integration test has been deleted
```