### PR TITLE
[CLOUDGA-24744] Add support for integration type VICTORIAMETRICS

### DIFF
--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -174,6 +174,9 @@ func init() {
 	createIntegrationCmd.Flags().StringToString("prometheus-spec", nil, `Configuration for prometheus. 
 	Please provide key value pairs as follows: 
 	endpoint=<prometheus-otlp-endpoint-url>`)
+	createIntegrationCmd.Flags().StringToString("victoriametrics-spec", nil, `Configuration for victoriametrics. 
+	Please provide key value pairs as follows: 
+	endpoint=<victoriametrics-otlp-endpoint-url>`)
 
 	if util.IsFeatureFlagEnabled(util.GOOGLECLOUD_INTEGRATION) {
 		createIntegrationCmd.Flags().String("googlecloud-cred-filepath", "", `Filepath for Google Cloud service account credentials. 
@@ -219,6 +222,17 @@ func setIntegrationConfiguration(cmd *cobra.Command, IntegrationName string, sin
 		}
 		prometheusSpec := ybmclient.NewPrometheusTelemetryProviderSpec(endpoint)
 		IntegrationSpec.SetPrometheusSpec(*prometheusSpec)
+	case ybmclient.TELEMETRYPROVIDERTYPEENUM_VICTORIAMETRICS:
+		if !cmd.Flags().Changed("victoriametrics-spec") {
+			return nil, fmt.Errorf("victoriametrics-spec is required for victoriametrics sink")
+		}
+		victoriametricsSpecs, _ := cmd.Flags().GetStringToString("victoriametrics-spec")
+		endpoint := victoriametricsSpecs["endpoint"]
+		if len(endpoint) < 1 {
+			return nil, fmt.Errorf("endpoint is a required field for victoriametrics-spec")
+		}
+		victoriametricsSpec := ybmclient.NewVictoriaMetricsTelemetryProviderSpec(endpoint)
+		IntegrationSpec.SetVictoriametricsSpec(*victoriametricsSpec)
 	case ybmclient.TELEMETRYPROVIDERTYPEENUM_GRAFANA:
 		if !cmd.Flags().Changed("grafana-spec") {
 			return nil, fmt.Errorf("grafana-spec is required for grafana sink")

--- a/cmd/test/fixtures/metrics-exporter-victoriametrics.json
+++ b/cmd/test/fixtures/metrics-exporter-victoriametrics.json
@@ -1,0 +1,19 @@
+{
+    "data": {
+        "spec": {
+            "name": "test",
+            "type": "VICTORIAMETRICS",
+            "victoriametrics_spec": {
+                "endpoint": "http://victoriametrics.yourcompany.com"
+            }
+        },
+        "info": {
+            "id": "9e3fabbc-849c-4a77-bdb2-9422e712e7dc",
+            "cluster_ids": [],
+            "metadata": {
+                "created_on": "2023-08-24T06:41:16.145Z",
+                "updated_on": "2023-08-24T06:41:16.145Z"
+            }
+        }
+    }
+}

--- a/internal/formatter/telemetry_provider.go
+++ b/internal/formatter/telemetry_provider.go
@@ -25,7 +25,8 @@ import (
 
 const defaultIntegrationListing = "table {{.ID}}\t{{.Name}}\t{{.Type}}"
 const defaultIntegrationDataDog = "table {{.ID}}\t{{.Name}}\t{{.Type}}\t{{.Site}}\t{{.ApiKey}}"
-const defaultIntegrationPrometheus = "table {{.ID}}\t{{.Name}}\t{{.Type}}\t{{.Endpoint}}"
+const defaultIntegrationPrometheus = "table {{.ID}}\t{{.Name}}\t{{.Type}}\t{{.PrometheusEndpoint}}"
+const defaultIntegrationVictoriaMetrics = "table {{.ID}}\t{{.Name}}\t{{.Type}}\t{{.VictoriaMetricsEndpoint}}"
 const defaultIntegrationGrafana = "table {{.ID}}\t{{.Name}}\t{{.Type}}\t{{.Zone}}\t{{.AccessTokenPolicy}}\t{{.InstanceId}}\t{{.OrgSlug}}"
 const defaultIntegrationSumologic = "table {{.ID}}\t{{.Name}}\t{{.Type}}\t{{.AccessKey}}\t{{.AccessID}}\t{{.InstallationToken}}"
 
@@ -44,6 +45,8 @@ func NewIntegrationFormat(source string, providerType string) Format {
 		format = defaultIntegrationDataDog
 	case string(ybmclient.TELEMETRYPROVIDERTYPEENUM_PROMETHEUS):
 		format = defaultIntegrationPrometheus
+	case string(ybmclient.TELEMETRYPROVIDERTYPEENUM_VICTORIAMETRICS):
+		format = defaultIntegrationVictoriaMetrics
 	case string(ybmclient.TELEMETRYPROVIDERTYPEENUM_GRAFANA):
 		format = defaultIntegrationGrafana
 	case string(ybmclient.TELEMETRYPROVIDERTYPEENUM_SUMOLOGIC):
@@ -61,19 +64,20 @@ func NewIntegrationFormat(source string, providerType string) Format {
 func NewIntegrationContext() *IntegrationContext {
 	IntegrationCtx := IntegrationContext{}
 	IntegrationCtx.Header = SubHeaderContext{
-		"Name":              nameHeader,
-		"ID":                "ID",
-		"Type":              "Type",
-		"Site":              "Site",
-		"ApiKey":            "ApiKey",
-		"InstanceId":        "InstanceId",
-		"OrgSlug":           "OrgSlug",
-		"AccessTokenPolicy": "Access Token Policy",
-		"Zone":              "Zone",
-		"InstallationToken": "InstallationToken",
-		"AccessID":          "Access ID",
-		"AccessKey":         "Access Key",
-		"Endpoint":          "Endpoint",
+		"Name":                    nameHeader,
+		"ID":                      "ID",
+		"Type":                    "Type",
+		"Site":                    "Site",
+		"ApiKey":                  "ApiKey",
+		"InstanceId":              "InstanceId",
+		"OrgSlug":                 "OrgSlug",
+		"AccessTokenPolicy":       "Access Token Policy",
+		"Zone":                    "Zone",
+		"InstallationToken":       "InstallationToken",
+		"AccessID":                "Access ID",
+		"AccessKey":               "Access Key",
+		"PrometheusEndpoint":      "Endpoint",
+		"VictoriaMetricsEndpoint": "Endpoint",
 	}
 	return &IntegrationCtx
 }
@@ -155,6 +159,11 @@ func IntegrationShortenKey(key string, stringLen int) string {
 }
 
 // Prometheus
-func (tp *IntegrationContext) Endpoint() string {
+func (tp *IntegrationContext) PrometheusEndpoint() string {
 	return tp.tp.Spec.GetPrometheusSpec().Endpoint
+}
+
+// Victoria Metrics
+func (tp *IntegrationContext) VictoriaMetricsEndpoint() string {
+	return tp.tp.Spec.GetVictoriametricsSpec().Endpoint
 }


### PR DESCRIPTION
### Create Integration
```shell

~/code/ybm-cli on CLOUDGA-24744 *5 ?1                                                                                                                          at 14:33:16
> mb && ./ybm integration create --config-name vm-test --type VICTORIAMETRICS  --victoriametrics-spec endpoint=http://victoriametrics.yourcompany.com
go build -ldflags="-X 'main.version=v0.1.0'" -o ybm
you are using insecure api endpoint http://127.0.0.1:5678
The Integration vm-test has been created
ID                                     Name      Type              Endpoint
8c02a496-5032-4a29-84fd-3838b901af09   vm-test   VICTORIAMETRICS   http://victoriametrics.yourcompany.com
```

### Delete Integration:
```shell
~/code/ybm-cli on CLOUDGA-24744 *5 ?1                                                                                                                          at 14:33:20
> mb && ./ybm integration delete --config-name vm-test
go build -ldflags="-X 'main.version=v0.1.0'" -o ybm
? Are you sure you want to delete config: vm-test Yes
you are using insecure api endpoint http://127.0.0.1:5678
The Integration vm-test has been deleted
```