### PR TITLE
Added deprecation messages for metrics export commands

### DIFF
--- a/cmd/metrics_exporter/metrics_exporter.go
+++ b/cmd/metrics_exporter/metrics_exporter.go
@@ -42,6 +42,8 @@ var createMetricsExporterCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create Metrics Exporter Config",
 	Long:  "Create Metrics Exporter Config",
+	Deprecated: "use \"integration create\" instead." +
+		"\nThis command was deprecated 2024-11-30 and will be supported until 2025-2-28.\n",
 	Run: func(cmd *cobra.Command, args []string) {
 
 		metricsExporterName, _ := cmd.Flags().GetString("config-name")
@@ -90,6 +92,8 @@ var listMetricsExporterCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List Metrics Exporter Config",
 	Long:  "List Metrics Exporter Config",
+	Deprecated: "use \"integration list\" instead." +
+		"\nThis command was deprecated 2024-11-30 and will be supported until 2025-2-28.\n",
 	Run: func(cmd *cobra.Command, args []string) {
 		authApi, err := ybmAuthClient.NewAuthApiClient()
 		if err != nil {
@@ -122,6 +126,8 @@ var describeMetricsExporterCmd = &cobra.Command{
 	Use:   "describe",
 	Short: "Describe Metrics Exporter Config",
 	Long:  "Describe Metrics Exporter Config",
+	Deprecated: "refer to \"integration\"." +
+		"\nThis command was deprecated 2024-11-30 and will be supported until 2025-2-28.\n",
 	Run: func(cmd *cobra.Command, args []string) {
 		authApi, err := ybmAuthClient.NewAuthApiClient()
 		if err != nil {
@@ -146,6 +152,8 @@ var deleteMetricsExporterCmd = &cobra.Command{
 	Use:   "delete",
 	Short: "Delete Metrics Exporter Config",
 	Long:  "Delete Metrics Exporter Config",
+	Deprecated: "use \"integration delete\" instead." +
+		"\nThis command was deprecated 2024-11-30 and will be supported until 2025-2-28.\n",
 	PreRun: func(cmd *cobra.Command, args []string) {
 		viper.BindPFlag("force", cmd.Flags().Lookup("force"))
 		configName, _ := cmd.Flags().GetString("config-name")
@@ -277,6 +285,8 @@ var updateMetricsExporterCmd = &cobra.Command{
 	Use:   "update",
 	Short: "Update Metrics Exporter Config",
 	Long:  "Update Metrics Exporter Config",
+	Deprecated: "refer to \"integration\"." +
+		"\nThis command was deprecated 2024-11-30 and will be supported until 2025-2-28.\n",
 	Run: func(cmd *cobra.Command, args []string) {
 		authApi, err := ybmAuthClient.NewAuthApiClient()
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.17.0
 	github.com/t-tomalak/logrus-easy-formatter v0.0.0-20190827215021-c074f06c5816
-	github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20241116155807-eab59d10ab1c
+	github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20241129094603-513ccfc1e5ae
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	golang.org/x/mod v0.20.0
 	golang.org/x/term v0.25.0

--- a/go.sum
+++ b/go.sum
@@ -282,8 +282,8 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/t-tomalak/logrus-easy-formatter v0.0.0-20190827215021-c074f06c5816 h1:J6v8awz+me+xeb/cUTotKgceAYouhIB3pjzgRd6IlGk=
 github.com/t-tomalak/logrus-easy-formatter v0.0.0-20190827215021-c074f06c5816/go.mod h1:tzym/CEb5jnFI+Q0k4Qq3+LvRF4gO3E2pxS8fHP8jcA=
-github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20241116155807-eab59d10ab1c h1:NhSquu8YYg8yQrceEmVkxYg/kwpvqXodSa2qw0/AlGk=
-github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20241116155807-eab59d10ab1c/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20241129094603-513ccfc1e5ae h1:DPZFx2PSJhrCfoZ5vjre2rwvoltlBB75chAlL0Zdapc=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20241129094603-513ccfc1e5ae/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
Added deprecation messages for metrics export commands
```
./ybm metrics-exporter list
Command "list" is deprecated, use "integration list" instead.
This command was deprecated 2024-11-30 and will be supported until 2025-2-28.
Name              Type
yash-dpn          DATADOG
prometheus-full   VICTORIAMETRICS