### PR TITLE
CLOUDGA-24211 Remove ID from integration cmd output

### DIFF
--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -68,8 +68,8 @@ var _ = Describe("Integration", func() {
 			Expect(err).NotTo(HaveOccurred())
 			session.Wait(2)
 			Expect(session.Out).Should(gbytes.Say(`The Integration test has been created
-ID                                     Name      Type      Site      ApiKey
-9e3fabbc-849c-4a77-bdb2-9422e712e7dc   ff        DATADOG   test      c4XXXXXXXXXXXXXXXXXXXXXXXXXXXX3d`))
+Name      Type      Site      ApiKey
+ff        DATADOG   test      c4XXXXXXXXXXXXXXXXXXXXXXXXXXXX3d`))
 			session.Kill()
 		})
 		It("should return required field name and type when not set", func() {
@@ -107,8 +107,8 @@ ID                                     Name      Type      Site      ApiKey
 			Expect(err).NotTo(HaveOccurred())
 			session.Wait(2)
 			Expect(session.Out).Should(gbytes.Say(`The Integration test has been created
-ID                                     Name      Type         Endpoint
-9e3fabbc-849c-4a77-bdb2-9422e712e7dc   test      PROMETHEUS   http://prometheus.yourcompany.com/api/v1/otlp`))
+Name      Type         Endpoint
+test      PROMETHEUS   http://prometheus.yourcompany.com/api/v1/otlp`))
 			session.Kill()
 		})
 		It("should return error when arg prometheus-spec not set", func() {
@@ -146,8 +146,8 @@ ID                                     Name      Type         Endpoint
 			Expect(err).NotTo(HaveOccurred())
 			session.Wait(2)
 			Expect(session.Out).Should(gbytes.Say(`The Integration test has been created
-ID                                     Name      Type              Endpoint
-9e3fabbc-849c-4a77-bdb2-9422e712e7dc   test      VICTORIAMETRICS   http://victoriametrics.yourcompany.com`))
+Name      Type              Endpoint
+test      VICTORIAMETRICS   http://victoriametrics.yourcompany.com`))
 			session.Kill()
 		})
 		It("should return error when arg victoriametrics-spec not set", func() {
@@ -185,8 +185,8 @@ ID                                     Name      Type              Endpoint
 			Expect(err).NotTo(HaveOccurred())
 			session.Wait(2)
 			Expect(session.Out).Should(gbytes.Say(`The Integration test has been created
-ID                                     Name      Type      Zone        Access Token Policy                InstanceId   OrgSlug
-92ceaa26-bac7-4842-9b3c-831a18a4f813   grafana   GRAFANA   test-zone   glXXXXXXXXXX...XXXXXXXXXXXXXXX==   1234456      ybmclitest`))
+Name      Type      Zone        Access Token Policy                InstanceId   OrgSlug
+grafana   GRAFANA   test-zone   glXXXXXXXXXX...XXXXXXXXXXXXXXX==   1234456      ybmclitest`))
 			session.Kill()
 		})
 		It("should return required field", func() {
@@ -214,8 +214,8 @@ ID                                     Name      Type      Zone        Access To
 			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
 			session.Wait(2)
-			Expect(session.Out).Should(gbytes.Say(`ID                                     Name         Type        Access Key                         Access ID        InstallationToken
-4021aa44-b22d-4bb6-a7d3-0a1099a4f206   gwenn-sumo   SUMOLOGIC   FqXXXXXXXXXX...XXXXXXXXXXXXXXX9p   suXXXXXXXXXXJ9   U1XXXXXXXXXX...XXXXXXXXXXXXXXX==`))
+			Expect(session.Out).Should(gbytes.Say(`Name         Type        Access Key                         Access ID        InstallationToken
+gwenn-sumo   SUMOLOGIC   FqXXXXXXXXXX...XXXXXXXXXXXXXXX9p   suXXXXXXXXXXJ9   U1XXXXXXXXXX...XXXXXXXXXXXXXXX==`))
 			session.Kill()
 		})
 		It("should return required field", func() {
@@ -244,8 +244,8 @@ ID                                     Name      Type      Zone        Access To
 			Expect(err).NotTo(HaveOccurred())
 			session.Wait(2)
 			Expect(session.Out).Should(gbytes.Say(`The Integration testgcp has been created
-ID                                     Name      Type
-7913c052-fcd0-4b37-8a90-b0e47320190b   ddd       GOOGLECLOUD`))
+Name      Type
+ddd       GOOGLECLOUD`))
 			session.Kill()
 		})
 		It("should return filepath error", func() {
@@ -300,10 +300,10 @@ ID                                     Name      Type
 			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
 			session.Wait(2)
-			Expect(session.Out).Should(gbytes.Say(`ID                                     Name         Type
-129f7c97-81ae-47c7-8f9e-40ab4390093f   ff           DATADOG
-92ceaa26-bac7-4842-9b3c-831a18a4f813   grafana      GRAFANA
-4021aa44-b22d-4bb6-a7d3-0a1099a4f206   gwenn-sumo   SUMOLOGIC`))
+			Expect(session.Out).Should(gbytes.Say(`Name         Type
+ff           DATADOG
+grafana      GRAFANA
+gwenn-sumo   SUMOLOGIC`))
 			session.Kill()
 		})
 

--- a/internal/formatter/telemetry_provider.go
+++ b/internal/formatter/telemetry_provider.go
@@ -23,12 +23,12 @@ import (
 	ybmclient "github.com/yugabyte/yugabytedb-managed-go-client-internal"
 )
 
-const defaultIntegrationListing = "table {{.ID}}\t{{.Name}}\t{{.Type}}"
-const defaultIntegrationDataDog = "table {{.ID}}\t{{.Name}}\t{{.Type}}\t{{.Site}}\t{{.ApiKey}}"
-const defaultIntegrationPrometheus = "table {{.ID}}\t{{.Name}}\t{{.Type}}\t{{.PrometheusEndpoint}}"
-const defaultIntegrationVictoriaMetrics = "table {{.ID}}\t{{.Name}}\t{{.Type}}\t{{.VictoriaMetricsEndpoint}}"
-const defaultIntegrationGrafana = "table {{.ID}}\t{{.Name}}\t{{.Type}}\t{{.Zone}}\t{{.AccessTokenPolicy}}\t{{.InstanceId}}\t{{.OrgSlug}}"
-const defaultIntegrationSumologic = "table {{.ID}}\t{{.Name}}\t{{.Type}}\t{{.AccessKey}}\t{{.AccessID}}\t{{.InstallationToken}}"
+const defaultIntegrationListing = "table {{.Name}}\t{{.Type}}"
+const defaultIntegrationDataDog = "table {{.Name}}\t{{.Type}}\t{{.Site}}\t{{.ApiKey}}"
+const defaultIntegrationPrometheus = "table {{.Name}}\t{{.Type}}\t{{.PrometheusEndpoint}}"
+const defaultIntegrationVictoriaMetrics = "table {{.Name}}\t{{.Type}}\t{{.VictoriaMetricsEndpoint}}"
+const defaultIntegrationGrafana = "table {{.Name}}\t{{.Type}}\t{{.Zone}}\t{{.AccessTokenPolicy}}\t{{.InstanceId}}\t{{.OrgSlug}}"
+const defaultIntegrationSumologic = "table {{.Name}}\t{{.Type}}\t{{.AccessKey}}\t{{.AccessID}}\t{{.InstallationToken}}"
 
 type IntegrationContext struct {
 	HeaderContext
@@ -94,10 +94,6 @@ func IntegrationWrite(ctx Context, Integrations []ybmclient.TelemetryProviderDat
 		return nil
 	}
 	return ctx.Write(NewIntegrationContext(), render)
-}
-
-func (tp *IntegrationContext) ID() string {
-	return tp.tp.Info.Id
 }
 
 func (tp *IntegrationContext) Name() string {


### PR DESCRIPTION
Remove ID from `integration` cmd output.

#### Before
```shell
~/code/ybm-cli on main *5 ?1                                                                                                                               INT at 16:48:46
> mb && ./ybm integration create --config-name vm-test-old --type VICTORIAMETRICS  --victoriametrics-spec endpoint=http://victoriametrics.yourcompany.com
go build -ldflags="-X 'main.version=v0.1.0'" -o ybm
The Integration vm-test-old has been created
ID                                     Name          Type              Endpoint
d1aa69d2-cf17-4049-94f0-f8cf87120b4c   vm-test-old   VICTORIAMETRICS   http://victoriametrics.yourcompany.com

```
#### Now
```shell
> mb && ./ybm integration create --config-name vm-test-new --type VICTORIAMETRICS  --victoriametrics-spec endpoint=http://victoriametrics.yourcompany.com
go build -ldflags="-X 'main.version=v0.1.0'" -o ybm
The Integration vm-test1 has been created
Name               Type              Endpoint
vm-test-new   VICTORIAMETRICS   http://victoriametrics.yourcompany.com
```