### PR TITLE
[CLOUDGA-25250] Fix error message for accepted sinks

### DIFF
--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -347,7 +347,7 @@ func setIntegrationConfiguration(cmd *cobra.Command, IntegrationName string, sin
 		googlecloudSpec := ybmclient.NewGCPServiceAccount(credType, projectId, privateKey, privateKeyId, clientEmail, clientId, authUri, tokenUri, authProviderX509CertUrl, clientX509CertUrl)
 		IntegrationSpec.SetGooglecloudSpec(*googlecloudSpec)
 	default:
-		return nil, fmt.Errorf("only datadog, grafana, googlecloud or sumologic are accepted as third party sink for now")
+		return nil, fmt.Errorf("only datadog, grafana, googlecloud, prometheus, victoriametrics or sumologic are accepted as third party sink for now")
 	}
 	return IntegrationSpec, nil
 }


### PR DESCRIPTION
- Fix error message for accepted sinks to include VM and Prometheus.

```shell
~/code/ybm-cli on main *5 !1 ?1                                                                                                                                at 19:35:17
> mb && ./ybm integration create --config-name vm-test-old \
--type NEWRELIC \
--victoriametrics-spec endpoint=http://victoriametrics.yourcompany.com
only datadog, grafana, googlecloud, prometheus, victoriametrics or sumologic are accepted as third party sink for now%
```