### PR TITLE
Bulk PITR config creation

### DIFF
--- a/cmd/test/fixtures/create-cluster-pitr-config.json
+++ b/cmd/test/fixtures/create-cluster-pitr-config.json
@@ -1,19 +1,38 @@
 {
-    "data": {
-      "spec": {
-        "database_type": "YSQL",
-        "database_name": "test_ysql_db",
-        "retention_period": 5
-      },
-      "info": {
-        "id": "3fb11555-b561-4e8f-b0ed-e77b8374cbc3",
-        "cluster_id": "95c522b3-dfd8-4654-ab10-99f59179ad7c",
-        "metadata": {
-          "created_on": "2024-08-07T16:26:08.435Z",
-          "updated_on": "2024-08-07T16:26:08.435Z"
+    "data": [
+      {
+        "spec": {
+          "database_type": "YSQL",
+          "database_name": "test_ysql_db",
+          "retention_period": 5
         },
-        "backup_interval": 86400,
-        "state": "QUEUED"
+        "info": {
+          "id": "3fb11555-b561-4e8f-b0ed-e77b8374cbc3",
+          "cluster_id": "95c522b3-dfd8-4654-ab10-99f59179ad7c",
+          "metadata": {
+            "created_on": "2024-08-07T16:26:08.435Z",
+            "updated_on": "2024-08-07T16:26:08.435Z"
+          },
+          "backup_interval": 86400,
+          "state": "QUEUED"
+        }
+      },
+      {
+        "spec": {
+          "database_type": "YCQL",
+          "database_name": "test_ycql_db",
+          "retention_period": 3
+        },
+        "info": {
+          "id": "249f9bf1-4276-4c60-8ab3-2bf1b2f6f1aa",
+          "cluster_id": "95c522b3-dfd8-4654-ab10-99f59179ad7c",
+          "metadata": {
+            "created_on": "2024-08-03T11:38:10.838Z",
+           "updated_on": "2024-08-03T11:38:10.838Z"
+          },
+          "backup_interval": 86400,
+          "state": "QUEUED"
+        }
       }
-    }
+    ]
   }

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.17.0
 	github.com/t-tomalak/logrus-easy-formatter v0.0.0-20190827215021-c074f06c5816
-	github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20241129094603-513ccfc1e5ae
+	github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20241219183048-50fe86c058d8
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	golang.org/x/mod v0.20.0
 	golang.org/x/term v0.25.0

--- a/go.sum
+++ b/go.sum
@@ -282,8 +282,8 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/t-tomalak/logrus-easy-formatter v0.0.0-20190827215021-c074f06c5816 h1:J6v8awz+me+xeb/cUTotKgceAYouhIB3pjzgRd6IlGk=
 github.com/t-tomalak/logrus-easy-formatter v0.0.0-20190827215021-c074f06c5816/go.mod h1:tzym/CEb5jnFI+Q0k4Qq3+LvRF4gO3E2pxS8fHP8jcA=
-github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20241129094603-513ccfc1e5ae h1:DPZFx2PSJhrCfoZ5vjre2rwvoltlBB75chAlL0Zdapc=
-github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20241129094603-513ccfc1e5ae/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20241219183048-50fe86c058d8 h1:criIjOTBfBOy0cZ23Qh2sOI0KLL3P4WKutnUhovUHPA=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20241219183048-50fe86c058d8/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1549,9 +1549,10 @@ func (a *AuthApiClient) ListClusterPitrConfigs(clusterId string) ybmclient.ApiLi
 	return a.ApiClient.ClusterApi.ListClusterPitrConfigs(a.ctx, a.AccountID, a.ProjectID, clusterId)
 }
 
-func (a *AuthApiClient) CreatePitrConfigSpec(databaseName string, databaseType string, retentionPeriodInDays int32) (*ybmclient.DatabasePitrConfigSpec, error) {
-	pitrConfigSpec := ybmclient.NewDatabasePitrConfigSpec(ybmclient.YbApiEnum(databaseType), databaseName, retentionPeriodInDays)
-	return pitrConfigSpec, nil
+func (a *AuthApiClient) CreateBulkPitrConfigSpec(specs []ybmclient.DatabasePitrConfigSpec) (*ybmclient.BulkCreateDatabasePitrConfigSpec, error) {
+	bulkPitrConfigSpec := ybmclient.NewBulkCreateDatabasePitrConfigSpec()
+	bulkPitrConfigSpec.SetPitrConfigSpecs(specs)
+	return bulkPitrConfigSpec, nil
 }
 
 func (a *AuthApiClient) CreatePitrConfig(clusterId string) ybmclient.ApiCreateDatabasePitrConfigRequest {


### PR DESCRIPTION
Change the create pitr-config command to work with updated API that takes in multiple config creation requests. Take the params as a string array and do required param validations for each config. 

Test plan:
1. Tested manually-
<img width="1329" alt="Screenshot 2024-12-20 at 10 29 32 AM" src="https://github.com/user-attachments/assets/76cb473f-6722-43e0-a305-382b01c9b88e" />

<img width="1332" alt="Screenshot 2024-12-20 at 11 26 08 AM" src="https://github.com/user-attachments/assets/4ebbb3dd-bb8a-4092-b6a2-cb462ff9569a" />

<img width="1327" alt="Screenshot 2024-12-20 at 11 29 02 AM" src="https://github.com/user-attachments/assets/abae90da-3544-4b3e-b245-a784ad613ed5" />

2. UTs
