### PR TITLE
[CLOUDGA-25138] Show api keys associated to an allow list in LIST AL cmd

### DIFF
--- a/cmd/api_key_test.go
+++ b/cmd/api_key_test.go
@@ -43,32 +43,8 @@ var _ = Describe("API Key Management", func() {
 		server.Close()
 	})
 
-	Describe("When listing API keys with allow list FF disabled", func() {
-		It("should hide allow list column", func() {
-			err := loadJson("./test/fixtures/list-api-keys.json", &apiKeyListResponse)
-			Expect(err).ToNot(HaveOccurred())
-
-			server.AppendHandlers(
-				ghttp.CombineHandlers(
-					ghttp.VerifyRequest(http.MethodGet, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/api-keys"),
-					ghttp.RespondWithJSONEncodedPtr(&statusCode, apiKeyListResponse),
-				),
-			)
-			os.Setenv("YBM_FF_API_KEY_ALLOW_LIST", "false")
-			cmd := exec.Command(compiledCLIPath, "api-key", "list")
-			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
-
-			Expect(err).NotTo(HaveOccurred())
-			session.Wait(2)
-			Expect(session.Out).Should(gbytes.Say(`Name       Role      Status    Created By    Date Created               Last Used                     Expiration
-apikey-1   Admin     ACTIVE    user@yb.com   2025-01-13T13:55:14.024Z   2025-01-13T14:21:40.713599Z   2099-12-31T00:00Z
-apikey-2   Admin     ACTIVE    user@yb.com   2025-01-08T09:06:35.077Z   Not yet used                  2025-02-07T09:06:35.077071Z`))
-			session.Kill()
-		})
-	})
-
-	Describe("When listing API keys with allow list FF enabled", func() {
-		It("should show allow list column", func() {
+	Describe("When listing API keys", func() {
+		It("should list api keys", func() {
 			err := loadJson("./test/fixtures/list-api-keys-with-allow-list.json", &apiKeyListResponse)
 			Expect(err).ToNot(HaveOccurred())
 			err = loadJson("./test/fixtures/allow-list.json", &responseNetworkAllowList)
@@ -85,7 +61,6 @@ apikey-2   Admin     ACTIVE    user@yb.com   2025-01-08T09:06:35.077Z   Not yet 
 				),
 			)
 
-			os.Setenv("YBM_FF_API_KEY_ALLOW_LIST", "true")
 			cmd := exec.Command(compiledCLIPath, "api-key", "list")
 			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 
@@ -100,80 +75,38 @@ apikey-2   Admin     ACTIVE    user@yb.com   2025-01-08T09:06:35.077Z   Not yet 
 	})
 
 	Describe("When creating an API key", func() {
-		Context("with allow list feature flag disabled", func() {
-			os.Setenv("YBM_FF_API_KEY_ALLOW_LIST", "false")
+		It("should create API key", func() {
+			err := loadJson("./test/fixtures/get-or-create-api-key.json", &apiKeyResponse)
+			Expect(err).ToNot(HaveOccurred())
+			err = loadJson("./test/fixtures/allow-list.json", &responseNetworkAllowList)
+			Expect(err).ToNot(HaveOccurred())
 
-			It("should error when passing allow list flag", func() {
-				os.Setenv("YBM_FF_API_KEY_ALLOW_LIST", "false")
-				cmd := exec.Command(compiledCLIPath, "api-key", "create", "--name", "apikey-1", "--duration", "30", "--unit", "DAYS", "--network-allow-lists", "device-ip")
-				session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/allow-lists"),
+					ghttp.RespondWithJSONEncodedPtr(&statusCode, responseNetworkAllowList),
+				),
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodPost, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/api-keys"),
+					ghttp.RespondWithJSONEncodedPtr(&statusCode, apiKeyResponse),
+				),
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/allow-lists"),
+					ghttp.RespondWithJSONEncodedPtr(&statusCode, responseNetworkAllowList),
+				),
+			)
 
-				Expect(err).NotTo(HaveOccurred())
-				session.Wait(2)
-				Expect(session.Err).Should(gbytes.Say(`\bError: unknown flag: --network-allow-lists\b`))
-				session.Kill()
-			})
+			cmd := exec.Command(compiledCLIPath, "api-key", "create", "--name", "apikey-1", "--duration", "30", "--unit", "DAYS", "--network-allow-lists", "device-ip-gween")
+			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 
-			It("should create API key", func() {
-				err := loadJson("./test/fixtures/get-or-create-api-key.json", &apiKeyResponse)
-				Expect(err).ToNot(HaveOccurred())
-
-				server.AppendHandlers(
-					ghttp.CombineHandlers(
-						ghttp.VerifyRequest(http.MethodPost, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/api-keys"),
-						ghttp.RespondWithJSONEncodedPtr(&statusCode, apiKeyResponse),
-					),
-				)
-
-				cmd := exec.Command(compiledCLIPath, "api-key", "create", "--name", "apikey-1", "--duration", "30", "--unit", "DAYS")
-				session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
-
-				Expect(err).NotTo(HaveOccurred())
-				session.Wait(2)
-				Expect(session.Out).Should(gbytes.Say(`Name       Role      Status    Created By   Date Created               Last Used      Expiration
-apikey-1   Admin     ACTIVE    admin        2025-01-13T15:55:55.825Z   Not yet used   2025-02-12T15:55:55.824833Z
-
-API Key: test-jwt`))
-				session.Kill()
-			})
-		})
-
-		Context("with allow list feature flag enabled", func() {
-			It("should create API key", func() {
-				err := loadJson("./test/fixtures/get-or-create-api-key.json", &apiKeyResponse)
-				Expect(err).ToNot(HaveOccurred())
-				err = loadJson("./test/fixtures/allow-list.json", &responseNetworkAllowList)
-				Expect(err).ToNot(HaveOccurred())
-
-				server.AppendHandlers(
-					ghttp.CombineHandlers(
-						ghttp.VerifyRequest(http.MethodGet, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/allow-lists"),
-						ghttp.RespondWithJSONEncodedPtr(&statusCode, responseNetworkAllowList),
-					),
-					ghttp.CombineHandlers(
-						ghttp.VerifyRequest(http.MethodPost, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/api-keys"),
-						ghttp.RespondWithJSONEncodedPtr(&statusCode, apiKeyResponse),
-					),
-					ghttp.CombineHandlers(
-						ghttp.VerifyRequest(http.MethodGet, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/allow-lists"),
-						ghttp.RespondWithJSONEncodedPtr(&statusCode, responseNetworkAllowList),
-					),
-				)
-
-				os.Setenv("YBM_FF_API_KEY_ALLOW_LIST", "true")
-				cmd := exec.Command(compiledCLIPath, "api-key", "create", "--name", "apikey-1", "--duration", "30", "--unit", "DAYS", "--network-allow-lists", "device-ip-gween")
-				session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
-
-				Expect(err).NotTo(HaveOccurred())
-				session.Wait(2)
-				Expect(session.Out).Should(gbytes.Say(`Name       Role      Status    Created By   Date Created               Last Used      Expiration                    Allow List
+			Expect(err).NotTo(HaveOccurred())
+			session.Wait(2)
+			Expect(session.Out).Should(gbytes.Say(`Name       Role      Status    Created By   Date Created               Last Used      Expiration                    Allow List
 apikey-1   Admin     ACTIVE    admin        2025-01-13T15:55:55.825Z   Not yet used   2025-02-12T15:55:55.824833Z   device-ip-gween
 
 API Key: test-jwt`))
-				session.Kill()
-			})
+			session.Kill()
 		})
-
 	})
 
 	Describe("When revoking an API key", func() {

--- a/cmd/util/feature_flags.go
+++ b/cmd/util/feature_flags.go
@@ -35,7 +35,6 @@ const (
 	PITR_RESTORE        FeatureFlag = "PITR_RESTORE"
 	CONNECTION_POOLING  FeatureFlag = "CONNECTION_POOLING"
 	DR                  FeatureFlag = "DR"
-	API_KEY_ALLOW_LIST  FeatureFlag = "API_KEY_ALLOW_LIST"
 )
 
 func (f FeatureFlag) String() string {

--- a/docs/ybm_api-key_create.md
+++ b/docs/ybm_api-key_create.md
@@ -13,13 +13,14 @@ ybm api-key create [flags]
 ### Options
 
 ```
-      --name string          [REQUIRED] The name of the API Key.
-      --duration int32       [REQUIRED] The duration for which the API Key will be valid. 0 denotes that the key will never expire.
-      --unit string          [REQUIRED] The time units for which the API Key will be valid. Available options are Hours, Days, and Months.
-      --description string   [OPTIONAL] Description of the API Key to be created.
-      --role-name string     [OPTIONAL] The name of the role to be assigned to the API Key. If not provided, an Admin API Key will be generated.
-  -f, --force                Bypass the prompt for non-interactive usage
-  -h, --help                 help for create
+      --name string                  [REQUIRED] The name of the API Key.
+      --duration int32               [REQUIRED] The duration for which the API Key will be valid. 0 denotes that the key will never expire.
+      --unit string                  [REQUIRED] The time units for which the API Key will be valid. Available options are Hours, Days, and Months.
+      --description string           [OPTIONAL] Description of the API Key to be created.
+      --network-allow-lists string   [OPTIONAL] The network allow lists(comma separated names) to assign to the API key.
+      --role-name string             [OPTIONAL] The name of the role to be assigned to the API Key. If not provided, an Admin API Key will be generated.
+  -f, --force                        Bypass the prompt for non-interactive usage
+  -h, --help                         help for create
 ```
 
 ### Options inherited from parent commands
@@ -28,6 +29,7 @@ ybm api-key create [flags]
   -a, --apiKey string      YugabyteDB Aeon account API key
       --config string      config file (default is $HOME/.ybm-cli.yaml)
       --debug              Use debug mode, same as --logLevel debug
+      --host string        YugabyteDB Aeon Api hostname
   -l, --logLevel string    Select the desired log level format(info). Default to info
       --no-color           Disable colors in output , default to false
   -o, --output string      Select the desired output format (table, json, pretty). Default to table

--- a/internal/formatter/api_keys.go
+++ b/internal/formatter/api_keys.go
@@ -20,13 +20,11 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
-	"github.com/yugabyte/ybm-cli/cmd/util"
 	ybmclient "github.com/yugabyte/yugabytedb-managed-go-client-internal"
 )
 
 const (
-	defaultApiKeyListing = "table {{.ApiKeyName}}\t{{.ApiKeyRole}}\t{{.ApiKeyStatus}}\t{{.Issuer}}\t{{.CreatedAt}}\t{{.LastUsed}}\t{{.ExpiryTime}}"
-	apiKeyListingV2      = "table {{.ApiKeyName}}\t{{.ApiKeyRole}}\t{{.ApiKeyStatus}}\t{{.Issuer}}\t{{.CreatedAt}}\t{{.LastUsed}}\t{{.ExpiryTime}}\t{{.AllowList}}"
+	defaultApiKeyListing = "table {{.ApiKeyName}}\t{{.ApiKeyRole}}\t{{.ApiKeyStatus}}\t{{.Issuer}}\t{{.CreatedAt}}\t{{.LastUsed}}\t{{.ExpiryTime}}\t{{.AllowList}}"
 	createdAtHeader      = "Date Created"
 	expiryTimeHeader     = "Expiration"
 	apiKeyRoleHeader     = "Role"
@@ -49,9 +47,6 @@ func NewApiKeyFormat(source string) Format {
 	switch source {
 	case "table", "":
 		format := defaultApiKeyListing
-		if util.IsFeatureFlagEnabled(util.API_KEY_ALLOW_LIST) {
-			format = apiKeyListingV2
-		}
 		return Format(format)
 	default: // custom format or json or pretty
 		return Format(source)

--- a/internal/formatter/network_allow_list.go
+++ b/internal/formatter/network_allow_list.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	defaultNalListing      = "table {{.Name}}\t{{.Desc}}\t{{.AllowedList}}\t{{.Clusters}}"
+	defaultNalListing      = "table {{.Name}}\t{{.Desc}}\t{{.AllowedList}}\t{{.Clusters}}\t{{.ApiKeys}}"
 	networkAllowListHeader = "Allow List"
 )
 
@@ -67,6 +67,7 @@ func NewNetworkAllowListContext() *NetworkAllowListContext {
 		"Clusters":    clustersHeader,
 		"Desc":        descriptionHeader,
 		"Name":        nameHeader,
+		"ApiKeys":     "API keys",
 	}
 	return &nalCtx
 }
@@ -89,6 +90,17 @@ func (c *NetworkAllowListContext) Clusters() string {
 	}
 	return strings.Join(clusterNameList, ",")
 }
+
+func (c *NetworkAllowListContext) ApiKeys() string {
+	var apiKeyNames []string
+	for _, apiKey := range c.c.GetInfo().ApiKeyList {
+		if apiKey.Status != nil && *apiKey.Status == ybmclient.APIKEYSTATUSENUM_ACTIVE {
+			apiKeyNames = append(apiKeyNames, apiKey.Name)
+		}
+	}
+	return strings.Join(apiKeyNames, ",")
+}
+
 func (c *NetworkAllowListContext) MarshalJSON() ([]byte, error) {
 	return json.Marshal(c.c)
 }


### PR DESCRIPTION
### Summary:
- [CLOUDGA-25138] Show api keys associated to an allow list in LIST AL cmd
- Remove FF for api key allow list

### Output:
```shell
~/code/ybm-cli on CLOUDGA-25138-fix *6 ?6                                                                                                             took 27s at 10:35:21
> mb && ./ybm network-allow-list list
Name      Description                       Allow List          Clusters   API keys
now                                         103.175.100.75/32              test-key,hello
my-mac    Allow list for my local machine   103.175.100.49/32              vaccextvpe,admin-nal-1ff3

```