### PR TITLE
Update create PITR spec with new request format, add update PITR and clone via PITR commands

### DIFF
--- a/cmd/pitr_config_test.go
+++ b/cmd/pitr_config_test.go
@@ -23,9 +23,11 @@ var _ = Describe("PITR Configs Test", func() {
 		responseAccount              openapi.AccountListResponse
 		responseProject              openapi.AccountListResponse
 		responseListCluster          openapi.ClusterListResponse
+		responseNamespace            openapi.ClusterNamespacesListResponse
 		responseListPITRConfig       openapi.ClusterPitrConfigListResponse
 		responseGetPITRConfig        openapi.DatabasePitrConfigResponse
 		responseCreatePITRConfig     openapi.BulkCreateDatabasePitrConfigResponse
+		responseUpdatePITRConfig     openapi.UpdateDatabasePitrConfigResponse
 		responseRestoreViaPITRConfig openapi.RestoreDatabaseViaPitrResponse
 	)
 
@@ -89,7 +91,15 @@ test_ysql_db   YSQL         5                          QUEUED    654321         
 
 	var _ = Describe("Create PITR config", func() {
 		It("Should successfully create PITR config", func() {
-			err := loadJson("./test/fixtures/create-cluster-pitr-config.json", &responseCreatePITRConfig)
+			err := loadJson("./test/fixtures/namespaces.json", &responseNamespace)
+			Expect(err).ToNot(HaveOccurred())
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/clusters/5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8/namespaces"),
+					ghttp.RespondWithJSONEncodedPtr(&statusCode, responseNamespace),
+				),
+			)
+			err = loadJson("./test/fixtures/create-cluster-pitr-config.json", &responseCreatePITRConfig)
 			Expect(err).ToNot(HaveOccurred())
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
@@ -106,6 +116,14 @@ test_ysql_db   YSQL         5                          QUEUED    654321         
 		})
 
 		It("Should fail if invalid namespace type in PITR Config", func() {
+			err := loadJson("./test/fixtures/namespaces.json", &responseNamespace)
+			Expect(err).ToNot(HaveOccurred())
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/clusters/5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8/namespaces"),
+					ghttp.RespondWithJSONEncodedPtr(&statusCode, responseNamespace),
+				),
+			)
 			cmd := exec.Command(compiledCLIPath, "cluster", "pitr-config", "create", "--cluster-name", "stunning-sole", "--pitr-config", "namespace-name=test_ysql_db, namespace-type=PGSQL, retention-period-in-days=5")
 			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
@@ -115,6 +133,14 @@ test_ysql_db   YSQL         5                          QUEUED    654321         
 		})
 
 		It("Should fail if empty namespace name in PITR Config", func() {
+			err := loadJson("./test/fixtures/namespaces.json", &responseNamespace)
+			Expect(err).ToNot(HaveOccurred())
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/clusters/5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8/namespaces"),
+					ghttp.RespondWithJSONEncodedPtr(&statusCode, responseNamespace),
+				),
+			)
 			cmd := exec.Command(compiledCLIPath, "cluster", "pitr-config", "create", "--cluster-name", "stunning-sole", "--pitr-config", "namespace-name=, namespace-type=YSQL, retention-period-in-days=5", "--pitr-config", "namespace-name=test_ycql_db, namespace-type=YCQL, retention-period-in-days=3")
 			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
@@ -124,6 +150,14 @@ test_ysql_db   YSQL         5                          QUEUED    654321         
 		})
 
 		It("Should fail if invalid key value pairs in PITR Config", func() {
+			err := loadJson("./test/fixtures/namespaces.json", &responseNamespace)
+			Expect(err).ToNot(HaveOccurred())
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/clusters/5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8/namespaces"),
+					ghttp.RespondWithJSONEncodedPtr(&statusCode, responseNamespace),
+				),
+			)
 			cmd := exec.Command(compiledCLIPath, "cluster", "pitr-config", "create", "--cluster-name", "stunning-sole", "--pitr-config", "namespace-name test_ysql_db, namespace-type=YSQL, retention-period-in-days=5", "--pitr-config", "namespace-name=test_ycql_db, namespace-type=YCQL, retention-period-in-days=3")
 			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
@@ -133,6 +167,14 @@ test_ysql_db   YSQL         5                          QUEUED    654321         
 		})
 
 		It("Should fail if all required params are not in PITR Config", func() {
+			err := loadJson("./test/fixtures/namespaces.json", &responseNamespace)
+			Expect(err).ToNot(HaveOccurred())
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/clusters/5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8/namespaces"),
+					ghttp.RespondWithJSONEncodedPtr(&statusCode, responseNamespace),
+				),
+			)
 			cmd := exec.Command(compiledCLIPath, "cluster", "pitr-config", "create", "--cluster-name", "stunning-sole", "--pitr-config", "namespace-name=test_ysql_db, namespace-type=YSQL ", "--pitr-config", "namespace-name=test_ycql_db, namespace-type=YCQL, retention-period-in-days=3")
 			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
@@ -142,6 +184,14 @@ test_ysql_db   YSQL         5                          QUEUED    654321         
 		})
 
 		It("Should fail if non int retention period in PITR Config", func() {
+			err := loadJson("./test/fixtures/namespaces.json", &responseNamespace)
+			Expect(err).ToNot(HaveOccurred())
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/clusters/5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8/namespaces"),
+					ghttp.RespondWithJSONEncodedPtr(&statusCode, responseNamespace),
+				),
+			)
 			cmd := exec.Command(compiledCLIPath, "cluster", "pitr-config", "create", "--cluster-name", "stunning-sole", "--pitr-config", "namespace-name=test_ysql_db, namespace-type=YSQL, retention-period-in-days=five", "--pitr-config", "namespace-name=test_ycql_db, namespace-type=YCQL, retention-period-in-days=3")
 			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
@@ -151,6 +201,14 @@ test_ysql_db   YSQL         5                          QUEUED    654321         
 		})
 
 		It("Should fail if less than one day retention period in PITR Config", func() {
+			err := loadJson("./test/fixtures/namespaces.json", &responseNamespace)
+			Expect(err).ToNot(HaveOccurred())
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/clusters/5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8/namespaces"),
+					ghttp.RespondWithJSONEncodedPtr(&statusCode, responseNamespace),
+				),
+			)
 			cmd := exec.Command(compiledCLIPath, "cluster", "pitr-config", "create", "--cluster-name", "stunning-sole", "--pitr-config", "namespace-name=test_ysql_db, namespace-type=YSQL, retention-period-in-days=1", "--pitr-config", "namespace-name=test_ycql_db, namespace-type=YCQL, retention-period-in-days=3")
 			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
@@ -163,7 +221,15 @@ test_ysql_db   YSQL         5                          QUEUED    654321         
 	var _ = Describe("Restore cluster namespace via PITR config", func() {
 		It("Should successfully restore YSQL namespace via PITR Config", func() {
 			os.Setenv("YBM_FF_PITR_RESTORE", "true")
-			err := loadJson("./test/fixtures/list-cluster-pitr-configs.json", &responseListPITRConfig)
+			err := loadJson("./test/fixtures/namespaces.json", &responseNamespace)
+			Expect(err).ToNot(HaveOccurred())
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/clusters/5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8/namespaces"),
+					ghttp.RespondWithJSONEncodedPtr(&statusCode, responseNamespace),
+				),
+			)
+			err = loadJson("./test/fixtures/list-cluster-pitr-configs.json", &responseListPITRConfig)
 			Expect(err).ToNot(HaveOccurred())
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
@@ -190,7 +256,15 @@ test_ysql_db   YSQL         5                          QUEUED    654321         
 
 		It("Should successfully restore YCQL namespace via PITR Config", func() {
 			os.Setenv("YBM_FF_PITR_RESTORE", "true")
-			err := loadJson("./test/fixtures/list-cluster-pitr-configs.json", &responseListPITRConfig)
+			err := loadJson("./test/fixtures/namespaces.json", &responseNamespace)
+			Expect(err).ToNot(HaveOccurred())
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/clusters/5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8/namespaces"),
+					ghttp.RespondWithJSONEncodedPtr(&statusCode, responseNamespace),
+				),
+			)
+			err = loadJson("./test/fixtures/list-cluster-pitr-configs.json", &responseListPITRConfig)
 			Expect(err).ToNot(HaveOccurred())
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
@@ -217,7 +291,15 @@ test_ysql_db   YSQL         5                          QUEUED    654321         
 
 		It("Should fail if invalid namespace name and type combination is provided", func() {
 			os.Setenv("YBM_FF_PITR_RESTORE", "true")
-			err := loadJson("./test/fixtures/list-cluster-pitr-configs.json", &responseListPITRConfig)
+			err := loadJson("./test/fixtures/namespaces.json", &responseNamespace)
+			Expect(err).ToNot(HaveOccurred())
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/clusters/5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8/namespaces"),
+					ghttp.RespondWithJSONEncodedPtr(&statusCode, responseNamespace),
+				),
+			)
+			err = loadJson("./test/fixtures/list-cluster-pitr-configs.json", &responseListPITRConfig)
 			Expect(err).ToNot(HaveOccurred())
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
@@ -229,14 +311,22 @@ test_ysql_db   YSQL         5                          QUEUED    654321         
 			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
 			session.Wait(2)
-			Expect(session.Err).Should(gbytes.Say("No PITR Configs found for YCQL namespace test_ysql_db in cluster stunning-sole.\n"))
+			Expect(session.Err).Should(gbytes.Say("No YCQL namespace found with name test_ysql_db in cluster stunning-sole.\n"))
 			session.Kill()
 		})
 	})
 
 	var _ = Describe("Describe Cluster PITR Config", func() {
 		It("Should successfully describe PITR Configs for the YSQL namespace in the cluster", func() {
-			err := loadJson("./test/fixtures/list-cluster-pitr-configs.json", &responseListPITRConfig)
+			err := loadJson("./test/fixtures/namespaces.json", &responseNamespace)
+			Expect(err).ToNot(HaveOccurred())
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/clusters/5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8/namespaces"),
+					ghttp.RespondWithJSONEncodedPtr(&statusCode, responseNamespace),
+				),
+			)
+			err = loadJson("./test/fixtures/list-cluster-pitr-configs.json", &responseListPITRConfig)
 			Expect(err).ToNot(HaveOccurred())
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
@@ -263,7 +353,15 @@ test_ysql_db   YSQL         5                          QUEUED    654321         
 		})
 
 		It("Should successfully describe PITR Configs for the YCQL namespace in the cluster", func() {
-			err := loadJson("./test/fixtures/list-cluster-pitr-configs.json", &responseListPITRConfig)
+			err := loadJson("./test/fixtures/namespaces.json", &responseNamespace)
+			Expect(err).ToNot(HaveOccurred())
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/clusters/5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8/namespaces"),
+					ghttp.RespondWithJSONEncodedPtr(&statusCode, responseNamespace),
+				),
+			)
+			err = loadJson("./test/fixtures/list-cluster-pitr-configs.json", &responseListPITRConfig)
 			Expect(err).ToNot(HaveOccurred())
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
@@ -290,6 +388,14 @@ test_ycql_db   YCQL         6                          ACTIVE    123456         
 		})
 
 		It("should fail if no PITR Configs found for the cluster", func() {
+			err := loadJson("./test/fixtures/namespaces.json", &responseNamespace)
+			Expect(err).ToNot(HaveOccurred())
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/clusters/5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8/namespaces"),
+					ghttp.RespondWithJSONEncodedPtr(&statusCode, responseNamespace),
+				),
+			)
 			responseListPITRConfig = *openapi.NewClusterPitrConfigListResponse()
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
@@ -301,12 +407,20 @@ test_ycql_db   YCQL         6                          ACTIVE    123456         
 			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
 			session.Wait(2)
-			Expect(session.Err).Should(gbytes.Say("No PITR Configs found for YCQL namespace different-db in cluster stunning-sole.\n"))
+			Expect(session.Err).Should(gbytes.Say("No YCQL namespace found with name different-db in cluster stunning-sole.\n"))
 			session.Kill()
 		})
 
 		It("Should fail if invalid namespace name and type combination is provided", func() {
-			err := loadJson("./test/fixtures/list-cluster-pitr-configs.json", &responseListPITRConfig)
+			err := loadJson("./test/fixtures/namespaces.json", &responseNamespace)
+			Expect(err).ToNot(HaveOccurred())
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/clusters/5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8/namespaces"),
+					ghttp.RespondWithJSONEncodedPtr(&statusCode, responseNamespace),
+				),
+			)
+			err = loadJson("./test/fixtures/list-cluster-pitr-configs.json", &responseListPITRConfig)
 			Expect(err).ToNot(HaveOccurred())
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
@@ -319,14 +433,22 @@ test_ycql_db   YCQL         6                          ACTIVE    123456         
 			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
 			session.Wait(2)
-			Expect(session.Err).Should(gbytes.Say("No PITR Configs found for YCQL namespace test_ysql_db in cluster stunning-sole.\n"))
+			Expect(session.Err).Should(gbytes.Say("No YCQL namespace found with name test_ysql_db in cluster stunning-sole.\n"))
 			session.Kill()
 		})
 	})
 
 	var _ = Describe("Delete Cluster PITR Config", func() {
 		It("Should successfully delete PITR Configs for the YSQL namespace in the cluster", func() {
-			err := loadJson("./test/fixtures/list-cluster-pitr-configs.json", &responseListPITRConfig)
+			err := loadJson("./test/fixtures/namespaces.json", &responseNamespace)
+			Expect(err).ToNot(HaveOccurred())
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/clusters/5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8/namespaces"),
+					ghttp.RespondWithJSONEncodedPtr(&statusCode, responseNamespace),
+				),
+			)
+			err = loadJson("./test/fixtures/list-cluster-pitr-configs.json", &responseListPITRConfig)
 			Expect(err).ToNot(HaveOccurred())
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
@@ -351,7 +473,15 @@ test_ycql_db   YCQL         6                          ACTIVE    123456         
 		})
 
 		It("Should successfully delete PITR Configs for the YCQL namespace in the cluster", func() {
-			err := loadJson("./test/fixtures/list-cluster-pitr-configs.json", &responseListPITRConfig)
+			err := loadJson("./test/fixtures/namespaces.json", &responseNamespace)
+			Expect(err).ToNot(HaveOccurred())
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/clusters/5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8/namespaces"),
+					ghttp.RespondWithJSONEncodedPtr(&statusCode, responseNamespace),
+				),
+			)
+			err = loadJson("./test/fixtures/list-cluster-pitr-configs.json", &responseListPITRConfig)
 			Expect(err).ToNot(HaveOccurred())
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
@@ -376,7 +506,15 @@ test_ycql_db   YCQL         6                          ACTIVE    123456         
 		})
 
 		It("Should fail if invalid namespace name and type combination is provided", func() {
-			err := loadJson("./test/fixtures/list-cluster-pitr-configs.json", &responseListPITRConfig)
+			err := loadJson("./test/fixtures/namespaces.json", &responseNamespace)
+			Expect(err).ToNot(HaveOccurred())
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/clusters/5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8/namespaces"),
+					ghttp.RespondWithJSONEncodedPtr(&statusCode, responseNamespace),
+				),
+			)
+			err = loadJson("./test/fixtures/list-cluster-pitr-configs.json", &responseListPITRConfig)
 			Expect(err).ToNot(HaveOccurred())
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
@@ -389,11 +527,19 @@ test_ycql_db   YCQL         6                          ACTIVE    123456         
 			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
 			session.Wait(2)
-			Expect(session.Err).Should(gbytes.Say("No PITR Configs found for YCQL namespace test_ysql_db in cluster stunning-sole.\n"))
+			Expect(session.Err).Should(gbytes.Say("No YCQL namespace found with name test_ysql_db in cluster stunning-sole.\n"))
 			session.Kill()
 		})
 
 		It("should fail if no PITR Configs found for the cluster", func() {
+			err := loadJson("./test/fixtures/namespaces.json", &responseNamespace)
+			Expect(err).ToNot(HaveOccurred())
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/clusters/5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8/namespaces"),
+					ghttp.RespondWithJSONEncodedPtr(&statusCode, responseNamespace),
+				),
+			)
 			responseListPITRConfig = *openapi.NewClusterPitrConfigListResponse()
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
@@ -405,7 +551,94 @@ test_ycql_db   YCQL         6                          ACTIVE    123456         
 			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
 			session.Wait(2)
-			Expect(session.Err).Should(gbytes.Say("No PITR Configs found for YCQL namespace different-db in cluster stunning-sole.\n"))
+			Expect(session.Err).Should(gbytes.Say("No YCQL namespace found with name different-db in cluster stunning-sole.\n"))
+			session.Kill()
+		})
+	})
+
+	var _ = Describe("Update PITR config", func() {
+		It("Should successfully update PITR Config", func() {
+			err := loadJson("./test/fixtures/namespaces.json", &responseNamespace)
+			Expect(err).ToNot(HaveOccurred())
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/clusters/5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8/namespaces"),
+					ghttp.RespondWithJSONEncodedPtr(&statusCode, responseNamespace),
+				),
+			)
+			err = loadJson("./test/fixtures/list-cluster-pitr-configs.json", &responseListPITRConfig)
+			Expect(err).ToNot(HaveOccurred())
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/clusters/5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8/pitr-configs"),
+					ghttp.RespondWithJSONEncodedPtr(&statusCode, responseListPITRConfig),
+				),
+			)
+			err = loadJson("./test/fixtures/update-cluster-pitr-config.json", &responseUpdatePITRConfig)
+			Expect(err).ToNot(HaveOccurred())
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodPut, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/clusters/5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8/pitr-configs/07de8b5e-ce57-4ab5-8e29-97e57b20e76f"),
+					ghttp.RespondWithJSONEncodedPtr(&statusCode, responseUpdatePITRConfig),
+				),
+			)
+
+			ysqlCmd := exec.Command(compiledCLIPath, "cluster", "pitr-config", "update", "--cluster-name", "stunning-sole", "--namespace-name", "test_ysql_db", "--namespace-type", "YSQL", "--retention-period-in-days", "6", "--force")
+			ysqlSession, ysqlErr := gexec.Start(ysqlCmd, GinkgoWriter, GinkgoWriter)
+			Expect(ysqlErr).NotTo(HaveOccurred())
+			ysqlSession.Wait(2)
+			Expect(ysqlSession.Out).Should(gbytes.Say("The PITR Configuration for YSQL namespace test_ysql_db in cluster stunning-sole is being updated."))
+			ysqlSession.Kill()
+		})
+
+		It("Should fail if invalid namespace name and type combination is provided", func() {
+			err := loadJson("./test/fixtures/namespaces.json", &responseNamespace)
+			Expect(err).ToNot(HaveOccurred())
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/clusters/5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8/namespaces"),
+					ghttp.RespondWithJSONEncodedPtr(&statusCode, responseNamespace),
+				),
+			)
+			err = loadJson("./test/fixtures/list-cluster-pitr-configs.json", &responseListPITRConfig)
+			Expect(err).ToNot(HaveOccurred())
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/clusters/5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8/pitr-configs"),
+					ghttp.RespondWithJSONEncodedPtr(&statusCode, responseListPITRConfig),
+				),
+			)
+
+			cmd := exec.Command(compiledCLIPath, "cluster", "pitr-config", "update", "--cluster-name", "stunning-sole", "--namespace-name", "test_ysql_db", "--namespace-type", "YCQL", "--retention-period-in-days", "6", "--force")
+			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+			session.Wait(2)
+			Expect(session.Err).Should(gbytes.Say("No YCQL namespace found with name test_ysql_db in cluster stunning-sole.\n"))
+			session.Kill()
+		})
+
+		It("Should fail if less than one day retention period in PITR Config", func() {
+			err := loadJson("./test/fixtures/namespaces.json", &responseNamespace)
+			Expect(err).ToNot(HaveOccurred())
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/clusters/5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8/namespaces"),
+					ghttp.RespondWithJSONEncodedPtr(&statusCode, responseNamespace),
+				),
+			)
+			err = loadJson("./test/fixtures/list-cluster-pitr-configs.json", &responseListPITRConfig)
+			Expect(err).ToNot(HaveOccurred())
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/clusters/5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8/pitr-configs"),
+					ghttp.RespondWithJSONEncodedPtr(&statusCode, responseListPITRConfig),
+				),
+			)
+			cmd := exec.Command(compiledCLIPath, "cluster", "pitr-config", "update", "--cluster-name", "stunning-sole", "--namespace-name", "test_ysql_db", "--namespace-type", "YSQL", "--retention-period-in-days", "1", "--force")
+			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+			session.Wait(2)
+			Expect(session.Err).Should(gbytes.Say("Minimum retention period is 2 days"))
 			session.Kill()
 		})
 	})

--- a/cmd/test/fixtures/clone-now-ysql-database.json
+++ b/cmd/test/fixtures/clone-now-ysql-database.json
@@ -1,0 +1,22 @@
+{
+    "data": {
+      "spec": {
+        "clone_now": {
+            "database_id": "000033c3-0000-3000-8000-000000000000",
+            "clone_as": "test_yugabyte_clone"
+        },
+        "clone_point_in_time": null
+      },
+      "info": {
+        "cluster_id": "5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8",
+        "metadata": {
+          "updated_on": "2024-08-07T17:26:08.435Z",
+          "created_on": "2024-08-07T17:26:08.435Z"
+        },
+        "database_type": "YSQL",
+        "database_name": "test_ysql_db",
+        "id": "8e74ca8f-331b-4dec-89b0-4e59b81e905d",
+        "state": "QUEUED"
+      }
+    }
+  }

--- a/cmd/test/fixtures/clone-ysql-database-via-pitr-config.json
+++ b/cmd/test/fixtures/clone-ysql-database-via-pitr-config.json
@@ -1,0 +1,23 @@
+{
+    "data": {
+      "spec": {
+        "clone_now": null,
+        "clone_point_in_time": {
+            "pitr_config_id": "07de8b5e-ce57-4ab5-8e29-97e57b20e76f",
+            "clone_at_millis": 4567,
+            "clone_as": "test_ysql_db_clone"
+        }
+      },
+      "info": {
+        "cluster_id": "5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8",
+        "metadata": {
+          "updated_on": "2024-08-07T17:26:08.435Z",
+          "created_on": "2024-08-07T17:26:08.435Z"
+        },
+        "database_type": "YSQL",
+        "database_name": "test_ysql_db",
+        "id": "8e74ca8f-331b-4dec-89b0-4e59b81e905d",
+        "state": "QUEUED"
+      }
+    }
+  }

--- a/cmd/test/fixtures/create-cluster-pitr-config.json
+++ b/cmd/test/fixtures/create-cluster-pitr-config.json
@@ -2,13 +2,14 @@
     "data": [
       {
         "spec": {
-          "database_type": "YSQL",
-          "database_name": "test_ysql_db",
+          "database_id": "00004002-0000-3000-8000-000000000000",
           "retention_period": 5
         },
         "info": {
           "id": "3fb11555-b561-4e8f-b0ed-e77b8374cbc3",
           "cluster_id": "95c522b3-dfd8-4654-ab10-99f59179ad7c",
+          "database_type": "YSQL",
+          "database_name": "test_ysql_db",
           "metadata": {
             "created_on": "2024-08-07T16:26:08.435Z",
             "updated_on": "2024-08-07T16:26:08.435Z"
@@ -19,13 +20,14 @@
       },
       {
         "spec": {
-          "database_type": "YCQL",
-          "database_name": "test_ycql_db",
+          "database_id": "9671367e-72c9-4593-be50-418cae59bf45",
           "retention_period": 3
         },
         "info": {
           "id": "249f9bf1-4276-4c60-8ab3-2bf1b2f6f1aa",
           "cluster_id": "95c522b3-dfd8-4654-ab10-99f59179ad7c",
+          "database_type": "YCQL",
+          "database_name": "test_ycql_db",
           "metadata": {
             "created_on": "2024-08-03T11:38:10.838Z",
            "updated_on": "2024-08-03T11:38:10.838Z"

--- a/cmd/test/fixtures/get-ycql-pitr-config.json
+++ b/cmd/test/fixtures/get-ycql-pitr-config.json
@@ -2,13 +2,14 @@
     "data": 
       {
         "spec": {
-          "database_type": "YCQL",
-          "database_name": "test_ycql_db",
+          "database_id": "9671367e-72c9-4593-be50-418cae59bf45",
           "retention_period": 6
         },
         "info": {
           "id": "249f9bf1-4276-4c60-8ab3-2bf1b2f6f1aa",
           "cluster_id": "95c522b3-dfd8-4654-ab10-99f59179ad7c",
+          "database_type": "YCQL",
+          "database_name": "test_ycql_db",
           "metadata": {
             "created_on": "2024-08-03T11:38:10.838Z",
             "updated_on": "2024-08-03T11:38:10.838Z"

--- a/cmd/test/fixtures/get-ysql-pitr-config.json
+++ b/cmd/test/fixtures/get-ysql-pitr-config.json
@@ -2,13 +2,14 @@
     "data": 
       {
         "spec": {
-          "database_type": "YSQL",
-          "database_name": "test_ysql_db",
+          "database_id": "00004002-0000-3000-8000-000000000000",
           "retention_period": 5
         },
         "info": {
           "id": "07de8b5e-ce57-4ab5-8e29-97e57b20e76f",
           "cluster_id": "95c522b3-dfd8-4654-ab10-99f59179ad7c",
+          "database_type": "YSQL",
+          "database_name": "test_ysql_db",
           "metadata": {
             "created_on": "2024-08-03T11:34:06.456Z",
             "updated_on": "2024-08-03T11:34:06.456Z"

--- a/cmd/test/fixtures/list-cluster-pitr-configs.json
+++ b/cmd/test/fixtures/list-cluster-pitr-configs.json
@@ -2,13 +2,14 @@
   "data": [
     {
       "spec": {
-        "database_type": "YSQL",
-        "database_name": "test_ysql_db",
+        "database_id": "00004002-0000-3000-8000-000000000000",
         "retention_period": 5
       },
       "info": {
         "id": "07de8b5e-ce57-4ab5-8e29-97e57b20e76f",
         "cluster_id": "95c522b3-dfd8-4654-ab10-99f59179ad7c",
+        "database_type": "YSQL",
+        "database_name": "test_ysql_db",
         "metadata": {
           "created_on": "2024-08-03T11:34:06.456Z",
           "updated_on": "2024-08-03T11:34:06.456Z"
@@ -21,13 +22,14 @@
     },
     {
       "spec": {
-        "database_type": "YCQL",
-        "database_name": "test_ycql_db",
+        "database_id": "9671367e-72c9-4593-be50-418cae59bf45",
         "retention_period": 6
       },
       "info": {
         "id": "249f9bf1-4276-4c60-8ab3-2bf1b2f6f1aa",
         "cluster_id": "95c522b3-dfd8-4654-ab10-99f59179ad7c",
+        "database_type": "YCQL",
+        "database_name": "test_ycql_db",
         "metadata": {
           "created_on": "2024-08-03T11:38:10.838Z",
           "updated_on": "2024-08-03T11:38:10.838Z"

--- a/cmd/test/fixtures/update-cluster-pitr-config.json
+++ b/cmd/test/fixtures/update-cluster-pitr-config.json
@@ -1,0 +1,23 @@
+{
+  "data": 
+    {
+      "spec": {
+        "database_id": "00004002-0000-3000-8000-000000000000",
+        "retention_period": 6
+      },
+      "info": {
+        "id": "07de8b5e-ce57-4ab5-8e29-97e57b20e76f",
+        "cluster_id": "95c522b3-dfd8-4654-ab10-99f59179ad7c",
+        "database_type": "YSQL",
+        "database_name": "test_ysql_db",
+        "metadata": {
+          "created_on": "2024-08-03T11:34:06.456Z",
+          "updated_on": "2024-08-03T11:34:06.456Z"
+        },
+        "backup_interval": 86400,
+        "state": "QUEUED",
+        "earliest_recovery_time_millis": 654321,
+        "latest_recovery_time_millis": 987654321
+      }
+    }
+}

--- a/cmd/util/feature_flags.go
+++ b/cmd/util/feature_flags.go
@@ -35,6 +35,7 @@ const (
 	PITR_RESTORE        FeatureFlag = "PITR_RESTORE"
 	CONNECTION_POOLING  FeatureFlag = "CONNECTION_POOLING"
 	DR                  FeatureFlag = "DR"
+	PITR_CLONE          FeatureFlag = "PITR_CLONE"
 )
 
 func (f FeatureFlag) String() string {

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.17.0
 	github.com/t-tomalak/logrus-easy-formatter v0.0.0-20190827215021-c074f06c5816
-	github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20250111091824-e051c979c3dd
+	github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20250128080628-17f7f0eade48
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	golang.org/x/mod v0.20.0
 	golang.org/x/term v0.25.0

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.17.0
 	github.com/t-tomalak/logrus-easy-formatter v0.0.0-20190827215021-c074f06c5816
-	github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20250128080628-17f7f0eade48
+	github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20250201211410-51dcbc34e9a3
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	golang.org/x/mod v0.20.0
 	golang.org/x/term v0.25.0

--- a/go.sum
+++ b/go.sum
@@ -282,8 +282,8 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/t-tomalak/logrus-easy-formatter v0.0.0-20190827215021-c074f06c5816 h1:J6v8awz+me+xeb/cUTotKgceAYouhIB3pjzgRd6IlGk=
 github.com/t-tomalak/logrus-easy-formatter v0.0.0-20190827215021-c074f06c5816/go.mod h1:tzym/CEb5jnFI+Q0k4Qq3+LvRF4gO3E2pxS8fHP8jcA=
-github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20250111091824-e051c979c3dd h1:vuMsPasq6Uzoy5fBJ0HJz7/jiCuLhKRj+LOyNVolqCk=
-github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20250111091824-e051c979c3dd/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20250128080628-17f7f0eade48 h1:6YuPp6iKm566uFx+ukx7HoEEYeaHXYrE13h5IpSXI10=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20250128080628-17f7f0eade48/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -282,8 +282,8 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/t-tomalak/logrus-easy-formatter v0.0.0-20190827215021-c074f06c5816 h1:J6v8awz+me+xeb/cUTotKgceAYouhIB3pjzgRd6IlGk=
 github.com/t-tomalak/logrus-easy-formatter v0.0.0-20190827215021-c074f06c5816/go.mod h1:tzym/CEb5jnFI+Q0k4Qq3+LvRF4gO3E2pxS8fHP8jcA=
-github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20250128080628-17f7f0eade48 h1:6YuPp6iKm566uFx+ukx7HoEEYeaHXYrE13h5IpSXI10=
-github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20250128080628-17f7f0eade48/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20250201211410-51dcbc34e9a3 h1:K+x7BoZbnpdq/3IXg8yOU5KoExlU6+1WTYhuHIlk2vM=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20250201211410-51dcbc34e9a3/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1580,6 +1580,14 @@ func (a *AuthApiClient) DeletePitrConfig(clusterId string, pitrConfigId string) 
 	return a.ApiClient.ClusterApi.RemoveDatabasePitrConfig(a.ctx, a.AccountID, a.ProjectID, clusterId, pitrConfigId)
 }
 
+func (a *AuthApiClient) UpdatePitrConfig(clusterId string, pitrConfigId string) ybmclient.ApiUpdateDatabasePitrConfigRequest {
+	return a.ApiClient.ClusterApi.UpdateDatabasePitrConfig(a.ctx, a.AccountID, a.ProjectID, clusterId, pitrConfigId)
+}
+
+func (a *AuthApiClient) CloneViaPitrConfig(clusterId string) ybmclient.ApiCloneDatabaseRequest {
+	return a.ApiClient.ClusterApi.CloneDatabase(a.ctx, a.AccountID, a.ProjectID, clusterId)
+}
+
 func (a *AuthApiClient) PerformConnectionPoolingOperation(clusterId string) ybmclient.ApiPerformConnectionPoolingOperationRequest {
 	return a.ApiClient.ClusterApi.PerformConnectionPoolingOperation(a.ctx, a.AccountID, a.ProjectID, clusterId)
 }

--- a/internal/formatter/pitr_configs.go
+++ b/internal/formatter/pitr_configs.go
@@ -62,7 +62,7 @@ func SinglePitrConfigWrite(ctx Context, pitrConfig ybmclient.DatabasePitrConfigD
 func PitrConfigWrite(ctx Context, pitrConfig []ybmclient.DatabasePitrConfigData) error {
 	//Sort by database name
 	sort.Slice(pitrConfig, func(i, j int) bool {
-		return string(pitrConfig[i].Spec.DatabaseName) < string(pitrConfig[j].Spec.DatabaseName)
+		return string(pitrConfig[i].Info.GetDatabaseName()) < string(pitrConfig[j].Info.GetDatabaseName())
 	})
 
 	render := func(format func(subContext SubContext) error) error {
@@ -92,11 +92,11 @@ func NewPitrConfigContext() *PitrConfigContext {
 }
 
 func (d *PitrConfigContext) Namespace() string {
-	return d.d.Spec.DatabaseName
+	return d.d.Info.GetDatabaseName()
 }
 
 func (d *PitrConfigContext) TableType() string {
-	return string(d.d.Spec.DatabaseType)
+	return string(d.d.Info.GetDatabaseType())
 }
 
 func (d *PitrConfigContext) RetentionPeriodInDays() int32 {


### PR DESCRIPTION
1. Create PITR config API now takes DB ID instead of <DB name, type>
2. Add support for update PITR config command
3. Add support for clone via PITR config command

Test plan:
Tested all flows manually.
UTs for clone via PITR and update PITR