### PR TITLE
[CLOUDGA-26189] Use new API's get instance-types, cloud-regions & node-configs

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -903,8 +903,8 @@ func (a *AuthApiClient) GetCdcStreamIDByStreamName(cdcStreamName string) (string
 	return "", fmt.Errorf("couldn't find any cdcStream with the given name")
 }
 
-func (a *AuthApiClient) GetSupportedNodeConfigurations(cloud string, tier string, region string) ybmclient.ApiGetSupportedNodeConfigurationsRequest {
-	return a.ApiClient.ClusterApi.GetSupportedNodeConfigurations(a.ctx).AccountId(a.AccountID).Cloud(cloud).Tier(tier).Regions([]string{region})
+func (a *AuthApiClient) GetSupportedNodeConfigurations(cloud string, tier string, region string) ybmclient.ApiGetSupportedNodeConfigurationsByAccountRequest {
+	return a.ApiClient.ClusterApi.GetSupportedNodeConfigurationsByAccount(a.ctx, a.AccountID).Cloud(cloud).Tier(tier).Regions([]string{region})
 }
 
 func (a *AuthApiClient) GetSupportedNodeConfigurationsV2(cloud string, tier string, regions []string, geoPartitioned bool) map[string][]ybmclient.NodeConfigurationResponseItem {
@@ -916,7 +916,7 @@ func (a *AuthApiClient) GetSupportedNodeConfigurationsV2(cloud string, tier stri
 	if len(regions) == 1 || cloud == "AZURE" || (geoPartitioned) {
 		isMultiRegion = false
 	}
-	instanceResp, resp, err := a.ApiClient.ClusterApi.GetSupportedNodeConfigurations(a.ctx).AccountId(a.AccountID).Cloud(cloud).Tier(tier).Regions(regions).IsMultiRegion(isMultiRegion).Execute()
+	instanceResp, resp, err := a.ApiClient.ClusterApi.GetSupportedNodeConfigurationsByAccount(a.ctx, a.AccountID).Cloud(cloud).Tier(tier).Regions(regions).IsMultiRegion(isMultiRegion).Execute()
 	if err != nil {
 		b, _ := httputil.DumpResponse(resp, true)
 		logrus.Debug(b)
@@ -995,8 +995,8 @@ func (a *AuthApiClient) PerformNodeOperation(clusterId string) ybmclient.ApiPerf
 	return a.ApiClient.ClusterApi.PerformNodeOperation(a.ctx, a.AccountID, a.ProjectID, clusterId)
 }
 
-func (a *AuthApiClient) GetSupportedCloudRegions() ybmclient.ApiGetSupportedCloudRegionsRequest {
-	return a.ApiClient.ClusterApi.GetSupportedCloudRegions(a.ctx)
+func (a *AuthApiClient) GetSupportedCloudRegions() ybmclient.ApiGetSupportedCloudRegionsByAccountRequest {
+	return a.ApiClient.ClusterApi.GetSupportedCloudRegionsByAccount(a.ctx, a.AccountID)
 }
 func (a *AuthApiClient) ListTasks() ybmclient.ApiListTasksRequest {
 	return a.ApiClient.TaskApi.ListTasks(a.ctx, a.AccountID)


### PR DESCRIPTION
- [CLOUDGA-26189] Use new API's for get instance-types, cloud-regions & node-configs.

Tested via running the below two commands and verifying the API call(via MITM proxy):
```sh
$ ./ybm region list --cloud-provider AWS

$ ./ybm region instance list --cloud-provider AWS --region ap-south-1
```
![image](https://github.com/user-attachments/assets/4873e511-73cd-4e9f-b3c0-6f8720d0bc81)
