### PR TITLE
[CLOUDGA-28934] Removed Connection Pooling feature flag from YBM-CLI.

### DIFF
--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -27,7 +27,6 @@ import (
 	"github.com/yugabyte/ybm-cli/cmd/cluster/node"
 	pitrconfig "github.com/yugabyte/ybm-cli/cmd/cluster/pitr-config"
 	readreplica "github.com/yugabyte/ybm-cli/cmd/cluster/read-replica"
-	"github.com/yugabyte/ybm-cli/cmd/util"
 )
 
 // getCmd represents the list command
@@ -75,7 +74,7 @@ func init() {
 	pitrconfig.PitrConfigCmd.PersistentFlags().StringVarP(&pitrconfig.ClusterName, "cluster-name", "c", "", "[REQUIRED] The name of the cluster.")
 	pitrconfig.PitrConfigCmd.MarkPersistentFlagRequired("cluster-name")
 
-	util.AddCommandIfFeatureFlag(ClusterCmd, connectionpooling.ConnectionPoolingCmd, util.CONNECTION_POOLING)
+	ClusterCmd.AddCommand(connectionpooling.ConnectionPoolingCmd)
 	connectionpooling.ConnectionPoolingCmd.PersistentFlags().StringVarP(&connectionpooling.ClusterName, "cluster-name", "c", "", "[REQUIRED] The name of the cluster.")
 	connectionpooling.ConnectionPoolingCmd.MarkPersistentFlagRequired("cluster-name")
 }

--- a/cmd/cluster/connection-pooling/connection_pooling.go
+++ b/cmd/cluster/connection-pooling/connection_pooling.go
@@ -21,7 +21,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/yugabyte/ybm-cli/cmd/util"
 	ybmAuthClient "github.com/yugabyte/ybm-cli/internal/client"
 	"github.com/yugabyte/ybm-cli/internal/formatter"
 	ybmclient "github.com/yugabyte/yugabytedb-managed-go-client-internal"
@@ -31,8 +30,8 @@ var ClusterName string
 
 var ConnectionPoolingCmd = &cobra.Command{
 	Use:   "connection-pooling",
-	Short: "Manage Connection Pooling",
-	Long:  "Manage Connection Pooling",
+	Short: "Manage Connection Pooling for a cluster",
+	Long:  "Manage Connection Pooling for a cluster",
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()
 	},
@@ -40,8 +39,8 @@ var ConnectionPoolingCmd = &cobra.Command{
 
 var enableConnectionPoolingCmd = &cobra.Command{
 	Use:   "enable",
-	Short: "Enable Connection Pooling",
-	Long:  "Enable Connection Pooling",
+	Short: "Enable Connection Pooling for a cluster",
+	Long:  "Enable Connection Pooling for a cluster",
 	Run: func(cmd *cobra.Command, args []string) {
 		performConnectionPoolingOperation("enable", cmd, args)
 	},
@@ -49,8 +48,8 @@ var enableConnectionPoolingCmd = &cobra.Command{
 
 var disableConnectionPoolingCmd = &cobra.Command{
 	Use:   "disable",
-	Short: "Disable Connection Pooling",
-	Long:  "Disable Connection Pooling",
+	Short: "Disable Connection Pooling for a cluster",
+	Long:  "Disable Connection Pooling for a cluster",
 	Run: func(cmd *cobra.Command, args []string) {
 		performConnectionPoolingOperation("disable", cmd, args)
 	},
@@ -103,7 +102,7 @@ func performConnectionPoolingOperation(operationName string, cmd *cobra.Command,
 }
 
 func init() {
-	util.AddCommandIfFeatureFlag(ConnectionPoolingCmd, enableConnectionPoolingCmd, util.CONNECTION_POOLING)
-
-	util.AddCommandIfFeatureFlag(ConnectionPoolingCmd, disableConnectionPoolingCmd, util.CONNECTION_POOLING)
+	ConnectionPoolingCmd.AddCommand()
+	ConnectionPoolingCmd.AddCommand(enableConnectionPoolingCmd)
+	ConnectionPoolingCmd.AddCommand(disableConnectionPoolingCmd)
 }

--- a/cmd/cluster/create_cluster.go
+++ b/cmd/cluster/create_cluster.go
@@ -132,14 +132,10 @@ var createClusterCmd = &cobra.Command{
 		// Enable connection pooling feature if requested
 		enableConnectionPooling, _ := cmd.Flags().GetBool("enable-connection-pooling")
 		if enableConnectionPooling {
-			if !util.IsFeatureFlagEnabled(util.CONNECTION_POOLING) {
-				logrus.Fatalf("Connection pooling feature is not enabled yet — it will be available soon.")
-			}
 			// Set connection pooling in features array for cluster creation
 			features := []ybmclient.CreateClusterFeatureEnum{ybmclient.CREATECLUSTERFEATUREENUM_ENABLE_CONNECTION_POOLING}
 			createClusterRequest.SetFeatures(features)
 			logrus.Debugf("Features array set to: %v", features)
-			logrus.Info("Connection pooling will be enabled during cluster creation")
 		}
 
 		if cmkSpec != nil {
@@ -237,5 +233,5 @@ func init() {
 	createClusterCmd.MarkFlagRequired("region-info")
 	createClusterCmd.Flags().String("preferred-region", "", "[OPTIONAL] The preferred region in a multi region cluster. The preferred region handles all read and write requests from clients.")
 	createClusterCmd.Flags().String("default-region", "", "[OPTIONAL] The primary region in a partition-by-region cluster. The primary region is where all the tables not created in a tablespace reside.")
-	createClusterCmd.Flags().Bool("enable-connection-pooling", false, "[OPTIONAL] Enable connection pooling for the cluster after creation. Default false.")
+	createClusterCmd.Flags().Bool("enable-connection-pooling", false, "[OPTIONAL] Enable connection pooling for the cluster during creation. Default false.")
 }

--- a/cmd/cluster_test.go
+++ b/cmd/cluster_test.go
@@ -54,7 +54,6 @@ var _ = Describe("Cluster", func() {
 		Expect(err).ToNot(HaveOccurred())
 		os.Setenv("YBM_HOST", fmt.Sprintf("http://%s", server.Addr()))
 		os.Setenv("YBM_APIKEY", "test-token")
-		os.Setenv("YBM_FF_CONNECTION_POOLING", "true")
 	})
 
 	Describe("Pausing cluster", func() {
@@ -208,20 +207,18 @@ var _ = Describe("Cluster", func() {
 		})
 		Context("with a valid Api token and default output table", func() {
 			It("should return list of cluster", func() {
-				os.Setenv("YBM_FF_CONNECTION_POOLING", "true")
 				cmd := exec.Command(compiledCLIPath, "cluster", "list")
 				session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).NotTo(HaveOccurred())
 				session.Wait(2)
 				o := string(session.Out.Contents()[:])
-				expected := `Name            Tier        Version       State     Health    Provider   Regions     Nodes     Node Res.(Vcpu/Mem/DiskGB/IOPS)   Connection Pooling Enabled
-stunning-sole   Dedicated   2.16.0.1-b7   ACTIVE    💚        AWS        us-west-2   1         2 / 8GB / 100GB / -               false` + "\n"
+				expected := `Name            Tier        Version       State     Health    Provider   Regions     Nodes     Node Res.(Vcpu/Mem/DiskGB/IOPS)   Connection Pooling
+stunning-sole   Dedicated   2.16.0.1-b7   ACTIVE    💚        AWS        us-west-2   1         2 / 8GB / 100GB / -               ❌` + "\n"
 				Expect(o).Should(Equal(expected))
 				session.Kill()
 			})
 
 			It("should return detailed summary of cluster if cluster-name is specified", func() {
-				os.Setenv("YBM_FF_CONNECTION_POOLING", "true")
 				statusCode = 200
 				err := loadJson("./test/fixtures/allow-list.json", &responseNetworkAllowList)
 				Expect(err).ToNot(HaveOccurred())
@@ -257,8 +254,8 @@ stunning-sole   Dedicated   2.16.0.1-b7   ACTIVE    💚        AWS        us-we
 Name            ID                                     Version       State     Health
 stunning-sole   5f80730f-ba3f-4f7e-8c01-f8fa4c90dad8   2.16.0.1-b7   ACTIVE    💚
 
-Provider   Tier        Fault Tolerance   Nodes     Node Res.(Vcpu/Mem/DiskGB/IOPS)   Connection Pooling Enabled
-AWS        Dedicated   NONE, RF 1        1         2 / 8GB / 100GB / -               false
+Provider   Tier        Fault Tolerance   Nodes     Node Res.(Vcpu/Mem/DiskGB/IOPS)   Connection Pooling
+AWS        Dedicated   NONE, RF 1        1         2 / 8GB / 100GB / -               ❌
 
 
 Regions
@@ -313,106 +310,6 @@ test-cli-2-n3   us-west-2[us-west-2c]   💚        ❌        ✅        ❌   
 	})
 
 	Describe("Creating cluster with connection pooling", func() {
-		// Note: We don't need a BeforeEach here because cluster creation doesn't start with a list clusters call
-		// The base server setup in newGhttpServer already handles the initial account/project calls
-		Context("when connection pooling flag is provided", func() {
-			It("should include ENABLE_CONNECTION_POOLING in features array", func() {
-				statusCode = 200
-				err := loadJson("./test/fixtures/create-cluster-with-cp.json", &responseCluster)
-				Expect(err).ToNot(HaveOccurred())
-
-				// Capture the request body to verify features array
-				var capturedRequestBody string
-				server.AppendHandlers(
-					// First, the CLI validates supported node configurations
-					ghttp.CombineHandlers(
-						ghttp.VerifyRequest(http.MethodGet, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/clusters/supported-node-configurations"),
-						ghttp.RespondWith(http.StatusOK, `{"data": [{"cloud": "GCP", "tier": "PAID", "regions": [{"name": "asia-south1"}], "node_configurations": [{"num_cores": 2, "memory_mb": 8192, "disk_size_gb": 50}]}]}`),
-					),
-					// Then the POST request for cluster creation
-					ghttp.CombineHandlers(
-						ghttp.VerifyRequest(http.MethodPost, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/projects/78d4459c-0f45-47a5-899a-45ddf43eba6e/clusters"),
-						ghttp.VerifyContentType("application/json"),
-						func(w http.ResponseWriter, req *http.Request) {
-							// Read and capture the request body
-							buf := make([]byte, req.ContentLength)
-							req.Body.Read(buf)
-							capturedRequestBody = string(buf)
-						},
-						ghttp.RespondWithJSONEncodedPtr(&statusCode, responseCluster),
-					),
-				)
-
-				cmd := exec.Command(compiledCLIPath, "cluster", "create",
-					"--cluster-name", "test-cp-cluster",
-					"--credentials", "username=admin,password=Secret123",
-					"--region-info", "region=asia-south1,num-nodes=1,num-cores=2,disk-size-gb=50",
-					"--cloud-provider", "GCP",
-					"--cluster-tier", "Dedicated",
-					"--enable-connection-pooling")
-
-				session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
-				Expect(err).NotTo(HaveOccurred())
-				session.Wait(5) // Allow time for cluster creation
-
-				// In test environment, the command may fail due to mock server limitations
-				// But we can verify that the CLI started and tried to run (exit code != 0 due to API errors is expected)
-				// The important thing is that the feature flag was enabled, so the CLI tried to proceed
-
-				if len(capturedRequestBody) > 0 {
-					// If we captured a request body, verify it contains connection pooling features
-					Expect(capturedRequestBody).Should(ContainSubstring("ENABLE_CONNECTION_POOLING"))
-					Expect(capturedRequestBody).Should(ContainSubstring("features"))
-				} else {
-					// In test environment, CLI may fail with API errors, but that's expected
-					// The fact that it attempted to run means our feature flag validation passed
-					output := string(session.Out.Contents())
-					errorOutput := string(session.Err.Contents())
-
-					// Either the command succeeded, or it failed due to API issues (both are acceptable)
-					hasAttemptedToRun := len(output) > 0 || len(errorOutput) > 0
-					Expect(hasAttemptedToRun).To(BeTrue(), "CLI should have attempted to run")
-				}
-
-				session.Kill()
-			})
-
-			It("should fail when feature flag is disabled", func() {
-				// Temporarily disable the feature flag
-				os.Setenv("YBM_FF_CONNECTION_POOLING", "false")
-				defer os.Setenv("YBM_FF_CONNECTION_POOLING", "true")
-
-				// Add handler for the GET request the CLI makes before attempting to create cluster
-				server.AppendHandlers(
-					ghttp.CombineHandlers(
-						ghttp.VerifyRequest(http.MethodGet, "/api/public/v1/accounts/340af43a-8a7c-4659-9258-4876fd6a207b/clusters/supported-node-configurations"),
-						ghttp.RespondWith(http.StatusOK, `{"data": [{"cloud": "GCP", "tier": "PAID", "regions": [{"name": "asia-south1"}], "node_configurations": [{"num_cores": 2, "memory_mb": 8192, "disk_size_gb": 50}]}]}`),
-					),
-				)
-
-				cmd := exec.Command(compiledCLIPath, "cluster", "create",
-					"--cluster-name", "test-cp-cluster-fail",
-					"--credentials", "username=admin,password=Secret123",
-					"--region-info", "region=asia-south1,num-nodes=1,num-cores=2,disk-size-gb=50",
-					"--cloud-provider", "GCP",
-					"--cluster-tier", "Dedicated",
-					"--enable-connection-pooling")
-
-				session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
-				Expect(err).NotTo(HaveOccurred())
-				session.Wait(5)
-
-				// Verify that the command fails (feature flag should prevent execution)
-				// We expect either a feature flag error or any other error indicating the CLI attempted to run
-				output := string(session.Err.Contents())
-
-				// The important thing is that the command failed when feature flag is disabled
-				Expect(session.ExitCode()).ToNot(Equal(0), "Command should have failed when feature flag disabled. Error output: %s", output)
-
-				session.Kill()
-			})
-		})
-
 		Context("when creating cluster with connection pooling enabled", func() {
 			It("should successfully create cluster with connection pooling feature", func() {
 				statusCode = 200

--- a/cmd/connection_pooling_test.go
+++ b/cmd/connection_pooling_test.go
@@ -45,7 +45,6 @@ var _ = Describe("Connection Pooling", func() {
 		Expect(err).ToNot(HaveOccurred())
 		os.Setenv("YBM_HOST", fmt.Sprintf("http://%s", server.Addr()))
 		os.Setenv("YBM_APIKEY", "test-token")
-		os.Setenv("YBM_FF_CONNECTION_POOLING", "true")
 		statusCode = 200
 		err = loadJson("./test/fixtures/list-clusters.json", &responseListClusters)
 		Expect(err).ToNot(HaveOccurred())

--- a/cmd/util/feature_flags.go
+++ b/cmd/util/feature_flags.go
@@ -33,7 +33,6 @@ const (
 	AZURE_CIDR_ALLOWED  FeatureFlag = "AZURE_CIDR_ALLOWED"
 	ENTERPRISE_SECURITY FeatureFlag = "ENTERPRISE_SECURITY"
 	PITR_RESTORE        FeatureFlag = "PITR_RESTORE"
-	CONNECTION_POOLING  FeatureFlag = "CONNECTION_POOLING"
 	DR                  FeatureFlag = "DR"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.17.0
 	github.com/t-tomalak/logrus-easy-formatter v0.0.0-20190827215021-c074f06c5816
-	github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20250809052019-ecd3dfbae333
+	github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20250818090100-de6585242c8e
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	golang.org/x/mod v0.20.0
 	golang.org/x/term v0.25.0

--- a/go.sum
+++ b/go.sum
@@ -282,8 +282,8 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/t-tomalak/logrus-easy-formatter v0.0.0-20190827215021-c074f06c5816 h1:J6v8awz+me+xeb/cUTotKgceAYouhIB3pjzgRd6IlGk=
 github.com/t-tomalak/logrus-easy-formatter v0.0.0-20190827215021-c074f06c5816/go.mod h1:tzym/CEb5jnFI+Q0k4Qq3+LvRF4gO3E2pxS8fHP8jcA=
-github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20250809052019-ecd3dfbae333 h1:h6QDVQtff2itBwi1TXbLyzI/r09FgBuLrmEyHiJ1C9Q=
-github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20250809052019-ecd3dfbae333/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20250818090100-de6585242c8e h1:DAwXWlzWoG8iqdzm1QuKP4+yJki4A3ML1qC9CoK7Maw=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20250818090100-de6585242c8e/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/internal/formatter/clusters_full.go
+++ b/internal/formatter/clusters_full.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/enescakir/emoji"
 	"github.com/sirupsen/logrus"
-	"github.com/yugabyte/ybm-cli/cmd/util"
 	"github.com/yugabyte/ybm-cli/internal/client"
 	"github.com/yugabyte/ybm-cli/internal/cluster"
 	ybmclient "github.com/yugabyte/yugabytedb-managed-go-client-internal"
@@ -34,8 +33,7 @@ import (
 
 const (
 	defaultFullClusterGeneral       = "table {{.Name}}\t{{.ID}}\t{{.SoftwareVersion}}\t{{.State}}\t{{.HealthState}}"
-	defaultFullClusterGeneral2      = "table {{.Provider}}\t{{.Tier}}\t{{.FaultTolerance}}\t{{.Nodes}}\t{{.NodesSpec}}"
-	defaultFullClusterGeneral2v2    = "table {{.Provider}}\t{{.Tier}}\t{{.FaultTolerance}}\t{{.Nodes}}\t{{.NodesSpec}}\t{{.ConnectionPoolingStatus}}"
+	defaultFullClusterGeneral2      = "table {{.Provider}}\t{{.Tier}}\t{{.FaultTolerance}}\t{{.Nodes}}\t{{.NodesSpec}}\t{{.ConnectionPoolingStatus}}"
 	defaultVPCListingCluster        = "table {{.Name}}\t{{.State}}\t{{.Provider}}\t{{.Regions}}\t{{.CIDR}}\t{{.Peerings}}"
 	defaultDefaultFullClusterRegion = "table {{.Region}}\t{{.NumNode}}\t{{.NumCores}}\t{{.MemoryGb}}\t{{.DiskSizeGb}}\t{{.VpcName}}"
 	defaultFullClusterNalListing    = "table {{.Name}}\t{{.Desc}}\t{{.AllowedList}}"
@@ -160,16 +158,9 @@ func (c *FullClusterContext) Write() error {
 
 	clusterContext := NewClusterContext()
 
-	if util.IsFeatureFlagEnabled(util.CONNECTION_POOLING) {
-		clusterContext = NewClusterContextV2()
-	}
 	c.postFormat(tmpl, clusterContext)
 
-	if util.IsFeatureFlagEnabled(util.CONNECTION_POOLING) {
-		tmpl, err = c.startSubsection(defaultFullClusterGeneral2v2)
-	} else {
-		tmpl, err = c.startSubsection(defaultFullClusterGeneral2)
-	}
+	tmpl, err = c.startSubsection(defaultFullClusterGeneral2)
 
 	if err != nil {
 		return err
@@ -181,9 +172,6 @@ func (c *FullClusterContext) Write() error {
 
 	clusterContext = NewClusterContext()
 
-	if util.IsFeatureFlagEnabled(util.CONNECTION_POOLING) {
-		clusterContext = NewClusterContextV2()
-	}
 	c.postFormat(tmpl, clusterContext)
 
 	//Regions Subsection


### PR DESCRIPTION
Tested locally without exporting Connection Pooling FF.

* Create 
```
ybm cluster create -h
Create a cluster

Usage:
  ybm cluster create [flags]

Flags:
      --cluster-name string            [REQUIRED] Name of the cluster.
....
      --enable-connection-pooling      [OPTIONAL] Enable connection pooling for the cluster during creation. Default false.
  -h, --help                           help for create

Global Flags:
  -a, --apiKey string      YugabyteDB Aeon account API key
....
```
* Modify Connection pooling status
```
ybm cluster -h                                                                 
Manage cluster operations

Usage:
  ybm cluster [flags]
  ybm cluster [command]

Available Commands:
  cert               Get the root CA certificate
  connection-pooling Manage Connection Pooling for a cluster
  create             Create a cluster
  db-audit-logging   Configure Database Audit Logging for your Cluster.
....
```
* Describe cluster
```
# ybm cluster describe --cluster-name puppy-heavy-workload-lrc-aws --output=table
General
Name                           ID                                     Version          State     Health
puppy-heavy-workload-lrc-aws   00000000-0000-0000-0000-000000000000   2024.1.6.0-b53   ACTIVE    💚

Provider   Tier        Fault Tolerance   Nodes     Node Res.(Vcpu/Mem/DiskGB/IOPS)   Connection Pooling
AWS        Dedicated   ZONE, RF 3        6         4 / 16GB / 1300GB / 3000          ❌

....
```