### PR TITLE
[CLOUDGA-33946] Documentation changes for new tracks

### DIFF
--- a/cmd/cluster/create_cluster.go
+++ b/cmd/cluster/create_cluster.go
@@ -207,7 +207,7 @@ func init() {
 	createClusterCmd.Flags().String("cloud-provider", "", "[OPTIONAL] The cloud provider where database needs to be deployed. AWS, AZURE or GCP. Default AWS.")
 	createClusterCmd.Flags().String("cluster-tier", "", "[OPTIONAL] The tier of the cluster. Sandbox or Dedicated. Default Sandbox.")
 	createClusterCmd.Flags().String("cluster-type", "", "[OPTIONAL] Cluster replication type. SYNCHRONOUS or GEO_PARTITIONED. Default SYNCHRONOUS.")
-	createClusterCmd.Flags().String("database-version", "", "[OPTIONAL] The database version of the cluster. Production, Innovation, Preview, or 'Early Access'. Default depends on cluster tier, Sandbox is Preview, Dedicated is Production.")
+	createClusterCmd.Flags().String("database-version", "", "[OPTIONAL] Database software track for the cluster. Supported values: Extended, Rapid.\nNOTE: Deprecated track names are no longer accepted. Production and Innovation were removed in favor of Extended. Preview and Early Access were removed in favor of Rapid.\nDefault when omitted depends on cluster tier: Sandbox uses Rapid, Dedicated uses Extended.")
 	createClusterCmd.Flags().Bool("enterprise-security", false, "[OPTIONAL] The security level of cluster. Advanced security will have security checks for cluster. Default false.")
 	createClusterCmd.Flags().String("encryption-spec", "", `[OPTIONAL] The customer managed key spec for the cluster.
 	Please provide key value pairs as follows:

--- a/cmd/cluster/update_cluster.go
+++ b/cmd/cluster/update_cluster.go
@@ -218,7 +218,7 @@ func init() {
 	updateClusterCmd.MarkFlagRequired("region-info")
 	updateClusterCmd.Flags().String("cluster-tier", "", "[OPTIONAL] The tier of the cluster. Sandbox or Dedicated.")
 	updateClusterCmd.Flags().String("fault-tolerance", "", "[OPTIONAL] Fault tolerance of the cluster. The possible values are NONE, NODE, ZONE, or REGION. Default NONE.")
-	updateClusterCmd.Flags().String("database-version", "", "[OPTIONAL] The database version of the cluster. Production, Innovation, Preview, or 'Early Access'.")
+	updateClusterCmd.Flags().String("database-version", "", "[OPTIONAL] Database software track for the cluster. Supported values: Extended, Rapid.\nNOTE: Deprecated track names are no longer accepted. Production and Innovation were removed in favor of Extended. Preview and Early Access were removed in favor of Rapid.")
 	updateClusterCmd.Flags().BoolP("force", "f", false, "Bypass the prompt for non-interactive usage")
 
 }

--- a/docs/ybm_cluster_create.md
+++ b/docs/ybm_cluster_create.md
@@ -18,7 +18,9 @@ ybm cluster create [flags]
       --cloud-provider string          [OPTIONAL] The cloud provider where database needs to be deployed. AWS, AZURE or GCP. Default AWS.
       --cluster-tier string            [OPTIONAL] The tier of the cluster. Sandbox or Dedicated. Default Sandbox.
       --cluster-type string            [OPTIONAL] Cluster replication type. SYNCHRONOUS or GEO_PARTITIONED. Default SYNCHRONOUS.
-      --database-version string        [OPTIONAL] The database version of the cluster. Production, Innovation, Preview, or 'Early Access'. Default depends on cluster tier, Sandbox is Preview, Dedicated is Production.
+      --database-version string        [OPTIONAL] Database software track for the cluster. Supported values: Extended, Rapid.
+                                       NOTE: Deprecated track names are no longer accepted. Production and Innovation were removed in favor of Extended. Preview and Early Access were removed in favor of Rapid.
+                                       Default when omitted depends on cluster tier: Sandbox uses Rapid, Dedicated uses Extended.
       --enterprise-security            [OPTIONAL] The security level of cluster. Advanced security will have security checks for cluster. Default false.
       --encryption-spec string         [OPTIONAL] The customer managed key spec for the cluster.
                                        	Please provide key value pairs as follows:

--- a/docs/ybm_cluster_update.md
+++ b/docs/ybm_cluster_update.md
@@ -17,7 +17,8 @@ ybm cluster update [flags]
       --cluster-name string       [REQUIRED] Name of the cluster.
       --cluster-tier string       [OPTIONAL] The tier of the cluster. Sandbox or Dedicated.
       --cluster-type string       [OPTIONAL] Cluster replication type. SYNCHRONOUS or GEO_PARTITIONED.
-      --database-version string   [OPTIONAL] The database version of the cluster. Production, Innovation, Preview, or 'Early Access'.
+      --database-version string   [OPTIONAL] Database software track for the cluster. Supported values: Extended, Rapid.
+                                  NOTE: Deprecated track names are no longer accepted. Production and Innovation were removed in favor of Extended. Preview and Early Access were removed in favor of Rapid.
       --fault-tolerance string    [OPTIONAL] Fault tolerance of the cluster. The possible values are NONE, NODE, ZONE, or REGION. Default NONE.
   -f, --force                     Bypass the prompt for non-interactive usage
   -h, --help                      help for update

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -880,13 +880,15 @@ func (a *AuthApiClient) GetTrackIdByName(trackName string) (string, error) {
 		return "", err
 	}
 
+	availableTrackNames := make([]string, 0, len(tracksNameResp.GetData()))
 	for _, track := range tracksNameResp.GetData() {
-		// Temporary backwards compatibility between Stable and Production tracks.
-		if track.Spec.GetName() == trackName || (track.Spec.GetName() == "Production" && trackName == "Stable") {
+		availableTrackNames = append(availableTrackNames, track.Spec.GetName())
+		if track.Spec.GetName() == trackName {
 			return track.Info.GetId(), nil
 		}
 	}
-	return "", fmt.Errorf("the database version doesn't exist")
+	sort.Strings(availableTrackNames)
+	return "", fmt.Errorf("database version %q was not found. Available database versions: %s\n", trackName, strings.Join(availableTrackNames, ", "))
 
 }
 func (a *AuthApiClient) CreateCdcStream(clusterId string) ybmclient.ApiCreateCdcStreamRequest {


### PR DESCRIPTION
## Summary

Since support for old track names will be removed with the new version. Hence updated the description for the `database-version` flag and its documentation.

Also updated the error message to list out the available tracks.

```bash
$ ./ybm cluster create --help
Create a cluster

Usage:
  ybm cluster create [flags]

Flags:
      --cluster-name string            [REQUIRED] Name of the cluster.
      --credentials stringToString     [REQUIRED] Credentials to login to the cluster. Please provide key value pairs username=<user-name>,password=<password>. (default [])
      --cloud-provider string          [OPTIONAL] The cloud provider where database needs to be deployed. AWS, AZURE or GCP. Default AWS.
      --cluster-tier string            [OPTIONAL] The tier of the cluster. Sandbox or Dedicated. Default Sandbox.
      --cluster-type string            [OPTIONAL] Cluster replication type. SYNCHRONOUS or GEO_PARTITIONED. Default SYNCHRONOUS.
      --database-version string        [OPTIONAL] Database software track for the cluster. Supported values: Extended, Rapid.
                                       NOTE: Deprecated track names are no longer accepted. Production and Innovation were removed in favor of Extended. Preview and Early Access were removed in favor of Rapid.
                                       Default when omitted depends on cluster tier: Sandbox uses Rapid, Dedicated uses Extended.
...
```

```bash
$ ./ybm cluster update --help
Update a cluster

Usage:
  ybm cluster update [flags]

Flags:
      --cloud-provider string     [OPTIONAL] The cloud provider where database needs to be deployed. AWS, AZURE or GCP.
      --cluster-name string       [REQUIRED] Name of the cluster.
      --cluster-tier string       [OPTIONAL] The tier of the cluster. Sandbox or Dedicated.
      --cluster-type string       [OPTIONAL] Cluster replication type. SYNCHRONOUS or GEO_PARTITIONED.
      --database-version string   [OPTIONAL] Database software track for the cluster. Supported values: Extended, Rapid.
                                  NOTE: Deprecated track names are no longer accepted. Production and Innovation were removed in favor of Extended. Preview and Early Access were removed in favor of Rapid.
      --fault-tolerance string    [OPTIONAL] Fault tolerance of the cluster. The possible values are NONE, NODE, ZONE, or REGION. Default NONE.
  -f, --force                     Bypass the prompt for non-interactive usage
  -h, --help                      help for update
      --new-name string           [OPTIONAL] The new name to be given to the cluster.
      --region-info stringArray   Region information for the cluster, provided as key-value pairs. Arguments are region=<region-name>,num-nodes=<number-of-nodes>,vpc=<vpc-name>,num-cores=<num-cores>,disk-size-gb=<disk-size-gb>,disk-iops=<disk-iops> (AWS only). region, num-nodes, num-cores, disk-size-gb are required. Specify one --region-info flag for each region in the cluster.
```

When old track name is passed:
```bash
$ ./ybm cluster create   --cluster-name my-gcp-cluster   --credentials username=admin,password='Password'   --cloud-provider GCP   --cluster-tier Dedicated   --cluster-type SYNCHRONOUS   --fault-tolerance NONE   --region-info region=us-west1,num-nodes=1,num-cores=2,disk-size-gb=100   --database-version Production
database version "Production" was not found. Available database versions: Extended, Rapid
```